### PR TITLE
Immutable Adler-32

### DIFF
--- a/lib/decompress_adler32.ml
+++ b/lib/decompress_adler32.ml
@@ -22,8 +22,8 @@ sig
   val init : unit -> t
   val make : int -> int -> t
 
-  val update  : buffer -> int -> int -> t -> unit
-  val atom    : atom -> t -> unit
+  val update  : buffer -> int -> int -> t -> t
+  val atom    : atom -> t -> t
   val combine : t -> t -> int -> t
 
   val eq  : t -> t -> bool
@@ -42,93 +42,95 @@ struct
   (* is the largest n such that 255n(n+1)/2 + (n+1)(base-1) <= 2^32-1 *)
 
   type t =
-    { mutable a1 : int
-    ; mutable a2 : int }
+    { a1 : int
+    ; a2 : int }
   (* [a1] and [a2] are mutable to avoid new allocation *)
 
   type atom = Atom.t
   type buffer = Scalar.t
 
   let do1 buffer current t =
-    t.a1 <- t.a1 + (Atom.code @@ Scalar.get buffer current);
-    t.a2 <- t.a1 + t.a2
+    let a1 = t.a1 + (Atom.code @@ Scalar.get buffer current) in
+    { a1; a2 = a1 + t.a2 }
 
   let do2 buffer current adler =
-    do1 buffer current adler;
-    do1 buffer (current + 1) adler
+    do1 buffer current adler
+    |> do1 buffer (current + 1)
 
   let do4 buffer current adler =
-    do2 buffer current adler;
-    do2 buffer (current + 2) adler
+    do2 buffer current adler
+    |> do2 buffer (current + 2)
 
   let do8 buffer current adler =
-    do4 buffer current adler;
-    do4 buffer (current + 4) adler
+    do4 buffer current adler
+    |> do4 buffer (current + 4)
 
   let do16 buffer current adler =
-    do8 buffer current adler;
-    do8 buffer (current + 8) adler
+    do8 buffer current adler
+    |> do8 buffer (current + 8)
 
   let init () = { a1 = 1; a2 = 0; }
 
   let make a1 a2 = { a1; a2; }
 
   let atom atom t =
-    t.a1 <- t.a1 + (Atom.code atom);
-    t.a2 <- t.a1 + t.a2;
-    if t.a1 >= base then t.a1 <- t.a1 - base;
-    if t.a2 >= base then t.a2 <- t.a2 - base
+    let a1 = t.a1 + (Atom.code atom) in
+    let a1 = if a1 >= base then a1 - base else a1 in
+    { a1
+    ; a2 = if a1 + t.a2 >= base then (a1 + t.a2) - base else a1 + t.a2 }
 
   let update buff off len t =
     match len with
-    | 0 -> ()
+    | 0 -> t
     | 1 -> atom (Scalar.get buff off) t
     | len when len < 16 ->
+      let t' = ref t in
       for i = 0 to len - 1 do
-        let c = Atom.code @@ Scalar.get buff (off + i) in
+        let chr = Atom.code @@ Scalar.get buff (off + i) in
         (* XXX: we don't use [atom] to avoid if t.a1 || t.a2 >= base *)
-        t.a1 <- t.a1 + c;
-        t.a2 <- t.a1 + t.a2;
+        t' := { a1 = !t'.a1 + chr
+              ; a2 = !t'.a1 + chr + !t'.a2 }
       done;
 
-      if t.a1 >= base then t.a1 <- t.a1 - base;
-      t.a2 <- t.a2 mod base
+      if !t'.a1 >= base then t' := { !t' with a1 = !t'.a1 - base };
+      { !t' with a2 = !t'.a2 mod base }
     | len ->
       let len = ref len in
       let cur = ref 0 in
+      let t'  = ref t in
 
       while !len >= nmax do
         for n = nmax / 16 downto 1 do
-          do16 buff (off + !cur) t;
+          t' := do16 buff (off + !cur) !t';
           cur := !cur + 16;
         done;
 
-        t.a1 <- t.a1 mod base;
-        t.a2 <- t.a2 mod base;
+        t' := { a1 = !t'.a1 mod base
+              ; a2 = !t'.a2 mod base };
 
         len := !len - nmax;
       done;
 
       if !len <> 0 then
         while !len >= 16 do
-          do16 buff (off + !cur) t;
+          t' := do16 buff (off + !cur) !t';
 
           cur := !cur + 16;
           len := !len - 16;
         done;
 
       while !len <> 0 do
-        let c = Atom.code @@ Scalar.get buff (off + !cur) in
+        let chr = Atom.code @@ Scalar.get buff (off + !cur) in
         (* XXX: we don't use [atom] to avoid if t.a1 || t.a2 >= base *)
-        t.a1 <- t.a1 + c;
-        t.a2 <- t.a1 + t.a2;
+        t' := { a1 = !t'.a1 + chr
+              ; a2 = !t'.a1 + chr + !t'.a2 };
 
         cur := !cur + 1;
         len := !len - 1;
       done;
 
-      t.a1 <- t.a1 mod base;
-      t.a2 <- t.a2 mod base
+      { a1 = !t'.a1 mod base
+      ; a2 = !t'.a2 mod base }
 
   let combine a b len =
     assert (len >= 0);
@@ -136,6 +138,7 @@ struct
     let len = len mod base in
     let r = { a1 = a.a1; a2 = (len * a.a1) mod base; } in
 
+    (* TODO
     r.a1 <- r.a1 + b.a1 + base - 1;
     r.a2 <- r.a2 + a.a2 + b.a2 + base - len;
 
@@ -143,6 +146,7 @@ struct
     if r.a1 >= base then r.a1 <- r.a1 - base;
     if r.a2 >= (base lsl 1) then r.a2 <- r.a2 - (base lsl 1);
     if r.a2 >= base then r.a2 <- r.a2 - base;
+    *)
 
     r
 

--- a/lib/decompress_adler32.mli
+++ b/lib/decompress_adler32.mli
@@ -22,8 +22,8 @@ sig
   val init : unit -> t
   val make : int -> int -> t
 
-  val update  : buffer -> int -> int -> t -> unit
-  val atom    : atom -> t -> unit
+  val update  : buffer -> int -> int -> t -> t
+  val atom    : atom -> t -> t
   val combine : t -> t -> int -> t
 
   val eq  : t -> t -> bool

--- a/lib/decompress_deflate.ml
+++ b/lib/decompress_deflate.ml
@@ -472,7 +472,7 @@ struct
           done;
 
           (* update CRC *)
-          Adler32.update deflater.src deflater.inpos len deflater.crc;
+          deflater.crc <- Adler32.update deflater.src deflater.inpos len deflater.crc;
 
           [%debug Logs.debug @@ fun m -> m "the size of new buffer of flat is %d" (real_size + len)];
 
@@ -486,10 +486,11 @@ struct
             deflater.inpos deflater.available;
 
           (* update CRC *)
-          Adler32.update deflater.src
-            deflater.inpos
-            deflater.available
-            deflater.crc;
+          deflater.crc <-
+            Adler32.update deflater.src
+              deflater.inpos
+              deflater.available
+              deflater.crc;
 
           Dynamic lz77, deflater.available
 
@@ -501,10 +502,11 @@ struct
             deflater.inpos deflater.available;
 
           (* update CRC *)
-          Adler32.update deflater.src
-            deflater.inpos
-            deflater.available
-            deflater.crc;
+          deflater.crc <-
+            Adler32.update deflater.src
+              deflater.inpos
+              deflater.available
+              deflater.crc;
 
           Static lz77, deflater.available
       in

--- a/lib/decompress_window.ml
+++ b/lib/decompress_window.ml
@@ -60,13 +60,13 @@ struct
 
   let add_buffer buff off len t =
     RingBuffer.write t.window buff off len;
-    CRC.update buff off len t.crc
+    t.crc <- CRC.update buff off len t.crc
 
   let add_atom atom t =
     let buff = Scalar.create 1 in
     Scalar.set buff 0 atom;
     RingBuffer.write t.window buff 0 1;
-    CRC.update buff 0 1 t.crc
+    t.crc <- CRC.update buff 0 1 t.crc
 
   let checksum t = t.crc
 


### PR DESCRIPTION
See [this article](http://web.archive.org/web/20100816130113/http://eigenclass.org/R2/writings/write-barrier-cost). May be is fastest to use immutable record than mutable record in Adler-32 compute.