### PR TITLE
Optimize inflate

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -44,6 +44,7 @@ Library decompress
   InternalModules:      Decompress_huffman, Decompress_tree, Decompress_heap,
                         Decompress_ringbuffer,
                         Decompress_lz77, Decompress_window, Decompress_adler32, Decompress_tables
+  NativeOpt:            -inline 1000
 
 Executable ppx_debug
   Path:                 ppx

--- a/lib/decompress_common.ml
+++ b/lib/decompress_common.ml
@@ -11,5 +11,6 @@ struct
 
   external get_u16 : t -> int -> int = "%caml_string_get16u"
   external get_u64 : t -> int -> int64 = "%caml_string_get64u"
+  let iblit = Bytes.blit_string
   let of_input x = Bytes.unsafe_of_string x
 end

--- a/lib/decompress_common.mli
+++ b/lib/decompress_common.mli
@@ -12,5 +12,7 @@ sig
   val get_u16 : t -> int -> int
   val get_u64 : t -> int -> int64
 
+  val iblit   : i -> int -> t -> int -> int -> unit
+
   val of_input  : i -> t
 end

--- a/lib/decompress_huffman.mli
+++ b/lib/decompress_huffman.mli
@@ -14,15 +14,10 @@ val leaf: 'a -> 'a t
 val depth : 'a t -> int
 val compress : default:'a -> 'a t -> 'a t
 
-type path =
-  | Bit of bool
-  | Nth of int
-
-exception Expected_data of int * path list
-exception Invalid_path
-
-val read_and_find : ?acc:path list -> get_bit:(unit -> bool) -> get_bits:(int -> int) -> 'a t -> 'a
-val read_and_find_with_path : ?acc:path list -> get_bit:(unit -> bool) -> get_bits:(int -> int) -> ?path:path list -> 'a t -> path list * 'a
+val read_and_find :
+  ((bool -> 'a -> 'b) -> 'a -> 'b) ->
+  (int -> (int -> 'a -> 'b) -> 'a -> 'b) ->
+  int t -> (int -> 'a -> 'b) -> 'a -> 'b
 
 val make : int array -> int -> int -> int -> int t
 val from_distribution : ?canonical:bool -> (float * 'a) list -> 'a t

--- a/lib/decompress_inflate.mli
+++ b/lib/decompress_inflate.mli
@@ -2,17 +2,20 @@ module type INPUT =
 sig
   type t
 
-  val get : t -> int -> char
-  val sub : t -> int -> int -> t
+  val get  : t -> int -> char
+  val sub  : t -> int -> int -> t
+  val make : int -> char -> t
 end
 
 module type OUTPUT =
 sig
   type t
+  type i
 
   val create : int -> t
   val length : t -> int
   val blit   : t -> int -> t -> int -> int -> unit
+  val iblit  : i -> int -> t -> int -> int -> unit
   val get    : t -> int -> char
   val set    : t -> int -> char -> unit
 end
@@ -26,15 +29,14 @@ sig
   val make : src -> dst -> t
   val eval : t -> [`Ok | `Flush | `Error | `Wait ]
 
-  val contents : t -> int
-  val flush    : t -> int -> unit
-  val refill   : t -> int -> unit
+  val flush    : int -> int -> t -> unit
+  val refill   : int -> int -> t -> unit
   val used_in  : t -> int
   val used_out : t -> int
 
   val decompress : src -> dst -> (src -> int) -> (dst -> int -> int) -> unit
 end
 
-module Make (I : INPUT) (O : OUTPUT) : S
+module Make (I : INPUT) (O : OUTPUT with type i = I.t) : S
   with type dst = O.t
    and type src = I.t

--- a/lib/decompress_ringbuffer.ml
+++ b/lib/decompress_ringbuffer.ml
@@ -133,8 +133,10 @@ struct
 
   let wpos t = t.wpos
   let rpos t = t.rpos
+
   let rec sanitize t i =
-    if i >= 0 then i mod t.size
+    if i >= 0 && i < t.size then i
+    else if i > t.size then sanitize t (i - t.size)
     else sanitize t (t.size - i)
 
   let rget t idx =
@@ -142,16 +144,12 @@ struct
      * it's not good assertion, so we need to found another assertion with
      * [rget]. *)
     let pre = t.wpos - idx in
-    [%debug Logs.debug @@ fun m -> m "we have reverse get with pre = %d - %d = %d" t.wpos idx pre];
     let pos = t.size - (abs pre) in
-    [%debug Logs.debug @@ fun m -> m "we have reverse get with pos = %d - %d = %d" t.size (abs pre) pos];
     if pre < 0
     then Scalar.get t.buffer pos
     else Scalar.get t.buffer pre
 
   let rsub t off len =
-    [%debug Logs.debug @@ fun m -> m "rsub [off: %d] and [len: %d]" off len];
-
     assert (off < available_to_read t);
 
     let buff = Scalar.create len in


### PR DESCRIPTION
* don't use `mod` operator
* limit the barrier of `caml_modify` only when I need to update the `Inflate.t` record
* CPS style in the `read_and_find` function to get the symbol in the Huffman tree