### PR TITLE
Try to use Bigarray instead string to force memmove/memcpy when we blit

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -95,6 +95,8 @@ Executable generate
   CompiledObject:       best
   BuildDepends:         bindings
   Build$:               flag(stub)
+  CSources:             bigstring.c
+  CCOpt:                -O2 -Wall -Wextra -Wno-unused-parameter
 
 SourceRepository master
   Type:                 git

--- a/bindings/bindings.ml
+++ b/bindings/bindings.ml
@@ -9,15 +9,47 @@ struct
   type t = (char, int8_unsigned_elt, c_layout) Array1.t
   type i = t
 
-  external get : t -> int -> char    = "%caml_ba_ref_1"
-  external set : t -> int -> char -> unit = "%caml_ba_set_1"
-  let sub : t -> int -> int -> t     = Array1.sub
-  let length : t -> int              = Array1.dim
-  let make : int -> char -> t        =
-    fun l c -> let a = Array1.create Bigarray.Char c_layout l in Array1.fill a c; a
-  let create : int -> t              = Array1.create Bigarray.Char c_layout
-  external blit : t -> int -> t -> int -> int -> unit             = "decompress_bigstring_blit"
-  external blit_string : string -> int -> t -> int -> int -> unit = "decompress_bigstring_blit_string"
+  let length
+  : t -> int
+  = Array1.dim
+
+  let make
+  : int -> char -> t
+  = fun l c -> let a = Array1.create Bigarray.Char c_layout l in Array1.fill a c; a
+
+  let create
+  : int -> t
+  = Array1.create Bigarray.Char c_layout
+
+  external blit
+  : t -> int -> t -> int -> int -> unit
+  = "decompress_bigstring_blit"
+  external blit_string
+  : string -> int -> t -> int -> int -> unit
+  = "decompress_bigstring_blit_string"
+  external get
+  : t -> int -> char
+  = "%caml_ba_ref_1"
+  external set
+  : t -> int -> char -> unit
+  = "%caml_ba_set_1"
+  external get_u16
+  : t -> int -> int
+  = "%caml_bigstring_get16u"
+  external get_u64
+  : t -> int -> int64
+  = "%caml_bigstring_get64u"
+  external of_input
+  : i -> t
+  = "%identity"
+
+  let sub
+  : t -> int -> int -> t
+  = fun t a b ->
+    let s = Array1.sub t a b in
+    let r = Array1.create Bigarray.Char c_layout b in
+    blit s 0 r 0 b; r
+
   let to_string arr =
     let b = Bytes.create (Array1.dim arr) in
 
@@ -27,11 +59,6 @@ struct
     Bytes.unsafe_to_string b
 
   let iblit = blit
-
-  external get_u16 : t -> int -> int   = "%caml_bigstring_get16u"
-  external get_u64 : t -> int -> int64 = "%caml_bigstring_get64u"
-
-  external of_input : i -> t = "%identity"
 end
 
 module Inflate = Inflate.Make(Bigstring)(Bigstring)

--- a/bindings/bindings.ml
+++ b/bindings/bindings.ml
@@ -2,8 +2,40 @@ open Ctypes
 open Foreign
 open Decompress
 
-module Inflate = Inflate.Make(ExtString)(ExtBytes)
-module Deflate = Deflate.Make(ExtString)(ExtBytes)
+module Bigstring =
+struct
+  open Bigarray
+
+  type t = (char, int8_unsigned_elt, c_layout) Array1.t
+  type i = t
+
+  external get : t -> int -> char    = "%caml_ba_ref_1"
+  external set : t -> int -> char -> unit = "%caml_ba_set_1"
+  let sub : t -> int -> int -> t     = Array1.sub
+  let length : t -> int              = Array1.dim
+  let make : int -> char -> t        =
+    fun l c -> let a = Array1.create Bigarray.Char c_layout l in Array1.fill a c; a
+  let create : int -> t              = Array1.create Bigarray.Char c_layout
+  external blit : t -> int -> t -> int -> int -> unit             = "decompress_bigstring_blit"
+  external blit_string : string -> int -> t -> int -> int -> unit = "decompress_bigstring_blit_string"
+  let to_string arr =
+    let b = Bytes.create (Array1.dim arr) in
+
+    for i = 0 to Bytes.length b - 1
+    do Bytes.set b i (get arr i) done;
+
+    Bytes.unsafe_to_string b
+
+  let iblit = blit
+
+  external get_u16 : t -> int -> int   = "%caml_bigstring_get16u"
+  external get_u64 : t -> int -> int64 = "%caml_bigstring_get64u"
+
+  external of_input : i -> t = "%identity"
+end
+
+module Inflate = Inflate.Make(Bigstring)(Bigstring)
+module Deflate = Deflate.Make(Bigstring)(Bigstring)
 
 let sp = Printf.sprintf
 
@@ -12,25 +44,25 @@ let inflate buff len chunk acc print =
   then raise (Invalid_argument (sp "inflate: we must have a chunk size %d >= 2" chunk));
 
   let buff   = Ctypes.string_from_ptr ~length:len buff in
-  let input  = Bytes.create chunk in
-  let output = Bytes.create chunk in
+  let input  = Bigstring.create chunk in
+  let output = Bigstring.create chunk in
   let position = ref 0 in
   let output_size = ref 0 in
 
   let refill' _ =
     let n = min (len - !position) chunk in
-    Bytes.blit_string buff !position input 0 n;
+    Bigstring.blit_string buff !position input 0 n;
     position := !position + n;
     n
   in
 
   let flush' _ len =
-    print ((Ctypes.coerce Ctypes.string (ptr char)) (Bytes.unsafe_to_string output)) 0 len acc;
+    print (Ctypes.bigarray_start Ctypes.array1 output) 0 len acc;
     output_size := !output_size + len;
     len
   in
 
-  Inflate.decompress (Bytes.unsafe_to_string input) output refill' flush';
+  Inflate.decompress input output refill' flush';
   !output_size
 
 let deflate buff len level chunk acc print =
@@ -38,25 +70,25 @@ let deflate buff len level chunk acc print =
   then raise (Invalid_argument (sp "deflate: we must have a chunk size %d >= 2" chunk));
 
   let buff   = Ctypes.string_from_ptr ~length:len buff in
-  let input  = Bytes.create chunk in
-  let output = Bytes.create chunk in
+  let input  = Bigstring.create chunk in
+  let output = Bigstring.create chunk in
   let position = ref 0 in
   let output_size = ref 0 in
 
   let refill' _ =
     let n = min (len - !position) chunk in
-    Bytes.blit_string buff !position input 0 n;
+    Bigstring.blit_string buff !position input 0 n;
     position := !position + n;
     if !position >= len then true, n else false, n
   in
 
   let flush' _ len =
-    print ((Ctypes.coerce Ctypes.string (ptr char)) (Bytes.unsafe_to_string output)) 0 len acc;
+    print (Ctypes.bigarray_start Ctypes.array1 output) 0 len acc;
     output_size := !output_size + len;
     len
   in
 
-  Deflate.compress ~level (Bytes.unsafe_to_string input) output refill' flush';
+  Deflate.compress ~level input output refill' flush';
   !output_size
 
 let print = funptr (ptr char @-> int @-> int @-> ptr void @-> returning void)

--- a/c/main.c
+++ b/c/main.c
@@ -74,11 +74,6 @@ main(int ac, const char **av)
     exit(EXIT_FAILURE);
   }
 
-  /*
-  char * caml_av[1] = { NULL };
-  caml_startup(caml_av);
-  */
-
   if (ac == 1)
   {
     (void) decompress_deflate(buf, len, LEVEL, CHUNK, NULL, &printer);

--- a/gen/bigstring.c
+++ b/gen/bigstring.c
@@ -1,0 +1,45 @@
+#include <string.h>
+#include <stdio.h>
+
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/fail.h>
+#include <caml/signals.h>
+#include <caml/bigarray.h>
+
+#define THREAD_IO_CUTOFF 65536
+
+static inline char * get_bstr(value v_bstr, value v_pos)
+{
+  return (char *) Caml_ba_data_val(v_bstr) + Long_val(v_pos);
+}
+
+CAMLprim value decompress_bigstring_blit(
+  value v_src, value v_src_pos, value v_dst, value v_dst_pos, value v_len)
+{
+  struct caml_ba_array *ba_src = Caml_ba_array_val(v_src);
+  struct caml_ba_array *ba_dst = Caml_ba_array_val(v_dst);
+  char *src = (char *) ba_src->data + Long_val(v_src_pos);
+  char *dst = (char *) ba_dst->data + Long_val(v_dst_pos);
+  size_t len = Long_val(v_len);
+  if (len > THREAD_IO_CUTOFF)
+  {
+    Begin_roots2(v_src, v_dst);
+    caml_enter_blocking_section();
+      memmove(dst, src, Long_val(v_len));
+    caml_leave_blocking_section();
+    End_roots();
+  }
+  else memmove(dst, src, Long_val(v_len));
+  return Val_unit;
+}
+
+CAMLprim value decompress_bigstring_blit_string(
+  value v_str, value v_src_pos, value v_bstr, value v_dst_pos, value v_len
+)
+{
+  char *str = String_val(v_str) + Long_val(v_src_pos);
+  char *bstr = get_bstr(v_bstr, v_dst_pos);
+  memcpy(bstr, str, Long_val(v_len));
+  return Val_unit;
+}

--- a/lib/libdecompress.stub
+++ b/lib/libdecompress.stub
@@ -4,3 +4,4 @@ stub/decompress_bindings.cmx
 bindings/apply_bindings.cmx
 stub/decompress.o
 stub/init.o
+gen/bigstring.o

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -185,6 +185,9 @@ let () = dispatch
         flag_and_dep [ "ocaml"; "ocamldep"; "use_decompress" ] logs;
         flag_and_dep [ "ocaml"; "compile";  "use_decompress" ] logs;
         flag_and_dep [ "ocaml"; "link";     "use_decompress" ] logs;
+        flag_and_dep [ "ocaml"; "ocamldep"; "inverted_stub" ] logs;
+        flag_and_dep [ "ocaml"; "compile";  "inverted_stub" ] logs;
+        flag_and_dep [ "ocaml"; "link";     "inverted_stub" ] logs;
       end;
 
       flag [ "ocaml"; "ocamldep"; "ppx_debug" ] (S [ A "-ppx"; A (cmd_debug trace) ]);


### PR DESCRIPTION
The `deflate` is wrong with this implementation and I don't know why (`inflate` works correctly). But I let this implementation to see later.
