### PR TITLE
Defunc

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -13,5 +13,6 @@ FLG -safe-string
 
 PKG alcotest re camlzip
 PKG oasis ocamlbuild compiler-libs
-PKG ppx_debug logs logs.cli
+PKG logs logs.cli
 PKG ctypes
+PKG core core_extended patience_diff pcre

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 install:
   - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
   - wget https://raw.githubusercontent.com/dinosaure/ocaml-travisci-skeleton/master/.travis-docgen.sh
-script: bash -ex .travis-cram.sh && bash -ex .travis-opam.sh && bash -ex .travis-docgen.sh
+script: bash -ex .travis-opam.sh && bash -ex .travis-docgen.sh
 sudo: true
 env:
   matrix:

--- a/_oasis
+++ b/_oasis
@@ -38,6 +38,12 @@ Flag stub
   Description:          Generate shared C library of Decompress
   Default:              false
 
+Library memcpy
+  Path:                 memcpy
+  Modules:              Memcpy
+  CSources:             memcpy/stub_memcpy.c
+  BuildDepends:         bigarray
+
 Library decompress
   Path:                 lib
   Modules:              Decompress, Decompress_common, Decompress_inflate, Decompress_deflate
@@ -45,6 +51,7 @@ Library decompress
                         Decompress_ringbuffer,
                         Decompress_lz77, Decompress_window, Decompress_adler32, Decompress_tables
   NativeOpt:            -inline 1000
+  BuildDepends:         memcpy
 
 Executable ppx_debug
   Path:                 ppx
@@ -77,7 +84,7 @@ Executable dcpr
   Path:                 bin/dcpr
   MainIs:               dcpr.ml
   CompiledObject:       best
-  BuildDepends:         decompress, unix, cmdliner, camlzip
+  BuildDepends:         decompress, unix, cmdliner, camlzip, core, core_extended, patience_diff, fmt, pcre, threads
   NativeOpt:            -inline 100
   Build$:               flag(example) && flag(unix) && flag(cmdliner) && flag(camlzip)
 
@@ -85,7 +92,7 @@ Object bindings
   Install:              false
   Path:                 bindings
   Modules:              Bindings
-  BuildDepends:         decompress, ctypes.stubs, ctypes.foreign
+  BuildDepends:         memcpy, decompress, ctypes.stubs, ctypes.foreign
   Build$:               flag(stub)
 
 Executable generate
@@ -93,7 +100,7 @@ Executable generate
   Path:                 gen
   MainIs:               generate.ml
   CompiledObject:       best
-  BuildDepends:         bindings
+  BuildDepends:         bindings, ctypes.stubs
   Build$:               flag(stub)
 
 SourceRepository master

--- a/_oasis
+++ b/_oasis
@@ -84,7 +84,7 @@ Executable dcpr
   Path:                 bin/dcpr
   MainIs:               dcpr.ml
   CompiledObject:       best
-  BuildDepends:         decompress, unix, cmdliner, camlzip, core, core_extended, patience_diff, fmt, pcre, threads
+  BuildDepends:         decompress, unix, cmdliner, camlzip
   NativeOpt:            -inline 100
   Build$:               flag(example) && flag(unix) && flag(cmdliner) && flag(camlzip)
 

--- a/_tags
+++ b/_tags
@@ -2,4 +2,5 @@
 # OASIS_STOP
 true: annot
 true: safe_string
+true: color(always)
 <lib/*.ml{,i}>: ppx_debug

--- a/_tags
+++ b/_tags
@@ -2,5 +2,4 @@
 # OASIS_STOP
 true: annot
 true: safe_string
-true: color(always)
 <lib/*.ml{,i}>: ppx_debug

--- a/bin/dcpr/dcpr.ml
+++ b/bin/dcpr/dcpr.ml
@@ -58,9 +58,6 @@ open Decompress
 
 module Inflate =
 struct
-  include
-  Inflate.Make(ExtString)(ExtBytes)
-
   let string ?(input_size = 2) ?(output_size = 2) document =
     let buffer   = Buffer.create 16 in
     let position = ref 0 in
@@ -70,8 +67,8 @@ struct
     let output   = Bytes.create output_size in
 
     let refill' input =
-      let n = min (size - !position) (String.length input) in
-      Bytes.blit_string document !position (Bytes.unsafe_of_string input) 0 n;
+      let n = min (size - !position) (Bytes.length input) in
+      Bytes.blit_string document !position input 0 n;
       position := !position + n;
       n
     in
@@ -81,14 +78,12 @@ struct
       size
     in
 
-    decompress (Bytes.unsafe_to_string input) output refill' flush';
+    Inflate.string input output refill' flush';
     Buffer.contents buffer
 end
 
 module Deflate =
 struct
-  include Deflate.Make(ExtString)(ExtBytes)
-
   let string ?(input_size = 2) ?(output_size = 2) ?(level = 4) ?(window_bits = 15) document =
     let buffer   = Buffer.create 16 in
     let position = ref 0 in
@@ -98,8 +93,8 @@ struct
     let output   = Bytes.create output_size in
 
     let refill' input =
-      let n = min (size - !position) (String.length input) in
-      Bytes.blit_string document !position (Bytes.unsafe_of_string input) 0 n;
+      let n = min (size - !position) (Bytes.length input) in
+      Bytes.blit_string document !position input 0 n;
       position := !position + n;
       if !position >= size then true, n else false, n
     in
@@ -109,7 +104,7 @@ struct
       size
     in
 
-    compress ~window_bits ~level (Bytes.unsafe_to_string input) output refill' flush';
+    Deflate.string ~window_bits ~level input output refill' flush';
     Buffer.contents buffer
 end
 
@@ -139,6 +134,69 @@ let string_of_channel ?(use_unix = true) ic =
   in
   loop b input s
 
+module Diff =
+struct
+  open Core.Std
+  open Core_extended.Std
+  open Patience_diff_lib
+
+  let ws_rex = Pcre.regexp "[\\s]+"
+  let ws_sub = Pcre.subst " "
+  let remove_ws s = String.strip (Pcre.replace ~rex:ws_rex ~itempl:ws_sub s)
+
+  let diff ~compare ~keep_ws o n =
+    if keep_ws then
+      let transform x = x in
+      Patience_diff.get_hunks ~context:0 ~mine:o ~other:n ~transform ~compare
+    else
+      let compare = fun x y -> compare (remove_ws x) (remove_ws y) in
+      let transform = remove_ws in
+      Patience_diff.get_hunks ~context:0 ~mine:o ~other:n ~transform ~compare
+
+  let compare_lines ?(keep_ws = true) o n =
+    let compare = String.compare in
+    let hunks = diff ~compare ~keep_ws o n in
+    Patience_diff.unified hunks
+
+  let string o n =
+    let lines text = String.split_lines text |> Array.of_list in
+    let hunks = compare_lines (lines o) (lines n) in
+    if Patience_diff.all_same hunks
+    then `Same
+    else `Different hunks
+end
+
+let hunks fmt =
+  let open Patience_diff_lib.Patience_diff in
+  let one' fmt = function
+    | Range.Same arr ->
+      Array.iter
+        (fun (a, b) -> Fmt.pf fmt " %a\n%!" (fun fmt -> Fmt.(styled `White string) fmt) a)
+        arr
+    | Range.New arr ->
+      Array.iter
+        (fun a -> Fmt.pf fmt "+%a\n%!" (fun fmt -> Fmt.(styled `Green string) fmt) a)
+        arr
+    | Range.Old arr ->
+      Array.iter
+        (fun a -> Fmt.pf fmt "-%a\n%!" (fun fmt -> Fmt.(styled `Red string) fmt) a)
+        arr
+    | Range.Unified arr ->
+      Array.iter
+        (fun a -> Fmt.pf fmt "!%a\n%!" (fun fmt -> Fmt.(styled `Yellow string) fmt) a)
+        arr
+    | Range.Replace (a, b) ->
+      Array.iter
+        (fun a -> Fmt.pf fmt "!%a\n%!" (fun fmt -> Fmt.(styled `Yellow string) fmt) a)
+        a
+  in
+  let one fmt { Hunk.mine_size; mine_start; other_size; other_start; ranges; } =
+    Fmt.pf fmt "-%d,%d +%d,%d\n%!" mine_start mine_size other_start other_size;
+    List.iter (fun r -> Fmt.pf fmt "%a" one' r) ranges
+  in List.iter (fun x -> Fmt.pf fmt "%a" one x)
+
+let () = Fmt.set_style_renderer Fmt.stdout `Ansi_tty
+
 open Cmdliner
 
 let do_cmd inf seed input_size output_size level window_bits use_camlzip =
@@ -156,7 +214,11 @@ let do_cmd inf seed input_size output_size level window_bits use_camlzip =
     | _ -> Inflate.string ~input_size ~output_size
   in
   deflater contents |> inflater
-  |> fun o -> Printf.printf "%b\n%!" (o = contents)
+  |> fun o ->
+
+    match Diff.string contents o with
+    | `Different diff -> Fmt.pf Fmt.stdout "%a" hunks diff
+    | `Same -> ()
 
 let file =
   let doc = "The input file. Reads from stdin if unspecified." in

--- a/bindings/bindings.ml
+++ b/bindings/bindings.ml
@@ -2,9 +2,6 @@ open Ctypes
 open Foreign
 open Decompress
 
-module Inflate = Inflate.Make(ExtString)(ExtBytes)
-module Deflate = Deflate.Make(ExtString)(ExtBytes)
-
 let sp = Printf.sprintf
 
 let inflate buff len chunk acc print =
@@ -30,7 +27,7 @@ let inflate buff len chunk acc print =
     len
   in
 
-  Inflate.decompress (Bytes.unsafe_to_string input) output refill' flush';
+  Inflate.string input output refill' flush';
   !output_size
 
 let deflate buff len level chunk acc print =
@@ -56,7 +53,7 @@ let deflate buff len level chunk acc print =
     len
   in
 
-  Deflate.compress ~level (Bytes.unsafe_to_string input) output refill' flush';
+  Deflate.string ~level input output refill' flush';
   !output_size
 
 let print = funptr (ptr char @-> int @-> int @-> ptr void @-> returning void)

--- a/lib/decompress.ml
+++ b/lib/decompress.ml
@@ -1,5 +1,2 @@
-module ExtString = Decompress_common.ExtString
-module ExtBytes  = Decompress_common.ExtBytes
-
 module Inflate = Decompress_inflate
 module Deflate = Decompress_deflate

--- a/lib/decompress_adler32.ml
+++ b/lib/decompress_adler32.ml
@@ -1,164 +1,117 @@
-module type ATOM =
-sig
-  type t
+open Decompress_common
 
-  val code : t -> int
-end
+let base = 65521
+(* largest prime smaller than 65536 *)
 
-module type SCALAR =
-sig
-  type elt
-  type t
+let nmax = 5552
+(* is the largest n such that 255n(n+1)/2 + (n+1)(base-1) <= 2^32-1 *)
 
-  val get : t -> int -> elt
-end
+type t =
+  { a1 : int
+  ; a2 : int }
 
-module type S =
-sig
-  type t
-  type atom
-  type buffer
+let do1 buffer current t =
+  let a1 = t.a1 + (Char.code @@ RO.get buffer current) in
+  { a1; a2 = a1 + t.a2 }
 
-  val init : unit -> t
-  val make : int -> int -> t
+let do2 buffer current adler =
+  do1 buffer current adler
+  |> do1 buffer (current + 1)
 
-  val update  : buffer -> int -> int -> t -> t
-  val atom    : atom -> t -> t
-  val combine : t -> t -> int -> t
+let do4 buffer current adler =
+  do2 buffer current adler
+  |> do2 buffer (current + 2)
 
-  val eq  : t -> t -> bool
-  val neq : t -> t -> bool
-  val get : t -> (int * int)
-end
+let do8 buffer current adler =
+  do4 buffer current adler
+  |> do4 buffer (current + 4)
 
-module Make (Atom : ATOM) (Scalar : SCALAR with type elt = Atom.t) : S
-  with type atom = Atom.t
-   and type buffer = Scalar.t =
-struct
-  let base = 65521
-  (* largest prime smaller than 65536 *)
+let do16 buffer current adler =
+  do8 buffer current adler
+  |> do8 buffer (current + 8)
 
-  let nmax = 5552
-  (* is the largest n such that 255n(n+1)/2 + (n+1)(base-1) <= 2^32-1 *)
+let default = { a1 = 1; a2 = 0; }
 
-  type t =
-    { a1 : int
-    ; a2 : int }
-  (* [a1] and [a2] are mutable to avoid new allocation *)
+let make a1 a2 = { a1; a2; }
 
-  type atom = Atom.t
-  type buffer = Scalar.t
+let atom atom t =
+  let a1 = t.a1 + (Char.code atom) in
+  let a1 = if a1 >= base then a1 - base else a1 in
+  { a1
+  ; a2 = if a1 + t.a2 >= base then (a1 + t.a2) - base else a1 + t.a2 }
 
-  let do1 buffer current t =
-    let a1 = t.a1 + (Atom.code @@ Scalar.get buffer current) in
-    { a1; a2 = a1 + t.a2 }
+let update buff off len t =
+  match len with
+  | 0 -> t
+  | 1 -> atom (RO.get buff off) t
+  | len when len < 16 ->
+    let t' = ref t in
+    for i = 0 to len - 1 do
+      let chr = Char.code @@ RO.get buff (off + i) in
+      (* XXX: we don't use [atom] to avoid if t.a1 || t.a2 >= base *)
+      t' := { a1 = !t'.a1 + chr
+            ; a2 = !t'.a1 + chr + !t'.a2 }
+    done;
 
-  let do2 buffer current adler =
-    do1 buffer current adler
-    |> do1 buffer (current + 1)
+    if !t'.a1 >= base then t' := { !t' with a1 = !t'.a1 - base };
+    { !t' with a2 = !t'.a2 mod base }
+  | len ->
+    let len = ref len in
+    let cur = ref 0 in
+    let t'  = ref t in
 
-  let do4 buffer current adler =
-    do2 buffer current adler
-    |> do2 buffer (current + 2)
-
-  let do8 buffer current adler =
-    do4 buffer current adler
-    |> do4 buffer (current + 4)
-
-  let do16 buffer current adler =
-    do8 buffer current adler
-    |> do8 buffer (current + 8)
-
-  let init () = { a1 = 1; a2 = 0; }
-
-  let make a1 a2 = { a1; a2; }
-
-  let atom atom t =
-    let a1 = t.a1 + (Atom.code atom) in
-    let a1 = if a1 >= base then a1 - base else a1 in
-    { a1
-    ; a2 = if a1 + t.a2 >= base then (a1 + t.a2) - base else a1 + t.a2 }
-
-  let update buff off len t =
-    match len with
-    | 0 -> t
-    | 1 -> atom (Scalar.get buff off) t
-    | len when len < 16 ->
-      let t' = ref t in
-      for i = 0 to len - 1 do
-        let chr = Atom.code @@ Scalar.get buff (off + i) in
-        (* XXX: we don't use [atom] to avoid if t.a1 || t.a2 >= base *)
-        t' := { a1 = !t'.a1 + chr
-              ; a2 = !t'.a1 + chr + !t'.a2 }
+    while !len >= nmax do
+      for n = nmax / 16 downto 1 do
+        t' := do16 buff (off + !cur) !t';
+        cur := !cur + 16;
       done;
 
-      if !t'.a1 >= base then t' := { !t' with a1 = !t'.a1 - base };
-      { !t' with a2 = !t'.a2 mod base }
-    | len ->
-      let len = ref len in
-      let cur = ref 0 in
-      let t'  = ref t in
+      t' := { a1 = !t'.a1 mod base
+            ; a2 = !t'.a2 mod base };
 
-      while !len >= nmax do
-        for n = nmax / 16 downto 1 do
-          t' := do16 buff (off + !cur) !t';
-          cur := !cur + 16;
-        done;
+      len := !len - nmax;
+    done;
 
-        t' := { a1 = !t'.a1 mod base
-              ; a2 = !t'.a2 mod base };
+    if !len <> 0 then
+      while !len >= 16 do
+        t' := do16 buff (off + !cur) !t';
 
-        len := !len - nmax;
+        cur := !cur + 16;
+        len := !len - 16;
       done;
 
-      if !len <> 0 then
-        while !len >= 16 do
-          t' := do16 buff (off + !cur) !t';
+    while !len <> 0 do
+      let chr = Char.code @@ RO.get buff (off + !cur) in
+      (* XXX: we don't use [atom] to avoid if t.a1 || t.a2 >= base *)
+      t' := { a1 = !t'.a1 + chr
+            ; a2 = !t'.a1 + chr + !t'.a2 };
 
-          cur := !cur + 16;
-          len := !len - 16;
-        done;
+      cur := !cur + 1;
+      len := !len - 1;
+    done;
 
-      while !len <> 0 do
-        let chr = Atom.code @@ Scalar.get buff (off + !cur) in
-        (* XXX: we don't use [atom] to avoid if t.a1 || t.a2 >= base *)
-        t' := { a1 = !t'.a1 + chr
-              ; a2 = !t'.a1 + chr + !t'.a2 };
+    { a1 = !t'.a1 mod base
+    ; a2 = !t'.a2 mod base }
 
-        cur := !cur + 1;
-        len := !len - 1;
-      done;
+let combine a b len =
+  assert (len >= 0);
 
-      { a1 = !t'.a1 mod base
-      ; a2 = !t'.a2 mod base }
+  let len = len mod base in
+  let r = { a1 = a.a1; a2 = (len * a.a1) mod base; } in
 
-  let combine a b len =
-    assert (len >= 0);
+  (* TODO
+  r.a1 <- r.a1 + b.a1 + base - 1;
+  r.a2 <- r.a2 + a.a2 + b.a2 + base - len;
 
-    let len = len mod base in
-    let r = { a1 = a.a1; a2 = (len * a.a1) mod base; } in
+  if r.a1 >= base then r.a1 <- r.a1 - base;
+  if r.a1 >= base then r.a1 <- r.a1 - base;
+  if r.a2 >= (base lsl 1) then r.a2 <- r.a2 - (base lsl 1);
+  if r.a2 >= base then r.a2 <- r.a2 - base;
+  *)
 
-    (* TODO
-    r.a1 <- r.a1 + b.a1 + base - 1;
-    r.a2 <- r.a2 + a.a2 + b.a2 + base - len;
+  r
 
-    if r.a1 >= base then r.a1 <- r.a1 - base;
-    if r.a1 >= base then r.a1 <- r.a1 - base;
-    if r.a2 >= (base lsl 1) then r.a2 <- r.a2 - (base lsl 1);
-    if r.a2 >= base then r.a2 <- r.a2 - base;
-    *)
+let eq a b  = (a.a1 = b.a1) && (a.a2 = b.a2)
+let neq a b = not (eq a b)
 
-    r
-
-  let eq a b =
-    (a.a1 = b.a1) && (a.a2 = b.a2)
-
-  let neq a b = not (eq a b)
-
-  let to_string { a1; a2; } =
-    let buffer = Buffer.create 16 in
-    Printf.bprintf buffer "[%02x; %02x]" a1 a2;
-    Buffer.contents buffer
-
-  let get { a1; a2; } = (a1, a2)
-end
+let get { a1; a2; } = (a1, a2)

--- a/lib/decompress_adler32.mli
+++ b/lib/decompress_adler32.mli
@@ -1,36 +1,14 @@
-module type ATOM =
-sig
-  type t
+open Decompress_common
 
-  val code : t -> int
-end
+type t
 
-module type SCALAR =
-sig
-  type elt
-  type t
+val default : t
+val make    : int -> int -> t
 
-  val get : t -> int -> elt
-end
+val update  : 'a RO.t -> int -> int -> t -> t
+val atom    : char -> t -> t
+val combine : t -> t -> int -> t
 
-module type S =
-sig
-  type t
-  type atom
-  type buffer
-
-  val init : unit -> t
-  val make : int -> int -> t
-
-  val update  : buffer -> int -> int -> t -> t
-  val atom    : atom -> t -> t
-  val combine : t -> t -> int -> t
-
-  val eq  : t -> t -> bool
-  val neq : t -> t -> bool
-  val get : t -> (int * int)
-end
-
-module Make (Atom : ATOM) (Scalar : SCALAR with type elt = Atom.t) : S
-  with type atom = Atom.t
-   and type buffer = Scalar.t
+val eq  : t -> t -> bool
+val neq : t -> t -> bool
+val get : t -> (int * int)

--- a/lib/decompress_common.ml
+++ b/lib/decompress_common.ml
@@ -1,16 +1,195 @@
-module ExtString =
-struct
-  include String
+module type BLIT =
+sig
+  type t
+
+  val blit : t -> int -> t -> int -> int -> unit
+  val blit_string : string -> int -> t -> int -> int -> unit
 end
 
-module ExtBytes =
+open Bigarray
+
+type bigstring = (char, int8_unsigned_elt, c_layout) Array1.t
+
+type normal = [ `Normal ]
+type fast   = [ `Fast ]
+
+let memcpy_bytes src dst len src_idx dst_idx =
+  if len < 0 || src_idx < 0 || src_idx > Bytes.length src - len
+             || dst_idx < 0 || dst_idx > Bytes.length dst - len
+  then raise (Invalid_argument "memcpy_bytes")
+  else Memcpy.memcpy_bytes src dst len src_idx dst_idx
+
+module Bigstring =
 struct
-  include Bytes
+  open Bigarray
 
-  type i = String.t
+  type t = bigstring
 
-  external get_u16 : t -> int -> int = "%caml_string_get16u"
-  external get_u64 : t -> int -> int64 = "%caml_string_get64u"
-  let iblit = Bytes.blit_string
-  let of_input x = Bytes.unsafe_of_string x
+  let length = Array1.dim
+  let create = Array1.create Bigarray.Char c_layout
+
+  let get : t -> int -> char = Array1.get
+  let set : t -> int -> char -> unit = Array1.set
+  let sub : t -> int -> int -> t = Array1.sub
+  let fill : t -> char -> unit = Array1.fill
+
+  external get_u16 : t -> int -> int   = "%caml_bigstring_get16u"
+  external get_u64 : t -> int -> int64 = "%caml_bigstring_get64u"
+
+  let to_string v =
+    let buf = Bytes.create (length v) in
+    for i = 0 to length v - 1
+    do Bytes.set buf i (get v i) done;
+    Bytes.unsafe_to_string buf
 end
+
+external string_get_u16 : string -> int -> int   = "%caml_string_get16u"
+external string_get_u64 : string -> int -> int64 = "%caml_string_get64u"
+
+(* Read only module *)
+module RO =
+struct
+  type 'a t =
+    | String : string -> normal t
+    | Bigstring : bigstring -> fast t
+
+  let from_string v    = String v
+  let from_bytes v     = String (Bytes.to_string v)
+  let from_bigstring v = Bigstring v
+
+  let length (type a) (v : a t) = match v with
+    | String v -> String.length v
+    | Bigstring v -> Bigstring.length v
+
+  let get (type a) (v : a t) = match v with
+    | String v -> String.get v
+    | Bigstring v -> Bigstring.get v
+
+  let get_u16 (type a) (v : a t) = match v with
+    | String v    -> string_get_u16 v
+    | Bigstring v -> Bigstring.get_u16 v
+
+  let get_u64 (type a) (v : a t) = match v with
+    | String v    -> string_get_u64 v
+    | Bigstring v -> Bigstring.get_u64 v
+
+  let sub (type a) (v : a t) a b : a t = match v with
+    | String v -> from_string @@ String.sub v a b
+    | Bigstring v -> from_bigstring @@ Bigstring.sub v a b
+
+  let pp (type a) fmt (v : a t) = match v with
+    | String v -> Format.fprintf fmt "%S" v
+    | Bigstring v -> Format.fprintf fmt "%S" (Bigstring.to_string v)
+end
+
+(* Read and Write module *)
+module RW =
+struct
+  type 'a t =
+    | Bytes     : bytes -> normal t
+    | Bigstring : bigstring -> fast t
+
+  let from_bytes v     = Bytes v
+  let from_string v    = Bytes (Bytes.of_string v)
+  let from_bigstring v = Bigstring v
+
+  let create_fast size =
+    Bigstring (Bigstring.create size)
+  let create_normal size =
+    Bytes (Bytes.create size)
+
+  let create_by (type a) (proof : a t) size : a t = match proof with
+    | Bytes _     -> Bytes (Bytes.create size)
+    | Bigstring _ -> Bigstring (Bigstring.create size)
+
+  let length (type a) (v : a t) = match v with
+    | Bytes v     -> Bytes.length v
+    | Bigstring v -> Bigstring.length v
+
+  let get (type a) (v : a t) = match v with
+    | Bytes v     -> Bytes.get v
+    | Bigstring v -> Bigstring.get v
+
+  let set (type a) (v : a t) = match v with
+    | Bytes v     -> Bytes.set v
+    | Bigstring v -> Bigstring.set v
+
+  let get_u16 (type a) (v : a t) = match v with
+    | Bytes v     -> string_get_u16 @@ Bytes.unsafe_to_string v
+    | Bigstring v -> Bigstring.get_u16 v
+
+  let get_u64 (type a) (v : a t) = match v with
+    | Bytes v     -> string_get_u64 @@ Bytes.unsafe_to_string v
+    | Bigstring v -> Bigstring.get_u64 v
+
+  let sub_ro (type a) (v : a t) i l : a RO.t = match v with
+    | Bytes v -> RO.from_string @@ Bytes.sub_string v i l
+    | Bigstring v ->
+      let ro = Bigstring.create l in
+      Array1.blit (Bigstring.sub v i l) ro;
+      RO.from_bigstring ro
+
+  let fill (type a) (v : a t) off len chr = match v with
+    | Bytes v -> Bytes.fill v off len chr
+    | Bigstring v ->
+      let s = Bigstring.sub v off len in
+      Bigstring.fill s chr
+end
+
+module Make (Blit : BLIT with type t = bigstring) =
+struct
+  include RW
+
+  let blit (type a) (src : a t) src_idx (dst : a t) dst_idx len =
+    match src, dst with
+    | Bytes src, Bytes dst ->
+      memcpy_bytes src dst len src_idx dst_idx
+    | Bigstring src, Bigstring dst ->
+      Blit.blit src src_idx dst dst_idx len
+
+  let blit_ro (type a) (src : a RO.t) src_idx (dst : a t) dst_idx len =
+    match src, dst with
+    | RO.String src, Bytes dst ->
+      (* XXX: not safe! *)
+      memcpy_bytes (Bytes.unsafe_of_string src) dst len src_idx dst_idx
+    | RO.Bigstring src, Bigstring dst ->
+      Blit.blit src src_idx dst dst_idx len
+
+  let blit_string (type a) src src_idx (dst : a t) dst_idx len =
+    match dst with
+    | Bytes dst ->
+      memcpy_bytes (Bytes.unsafe_of_string src) dst len src_idx dst_idx
+    | Bigstring dst ->
+      Blit.blit_string src src_idx dst dst_idx len
+end
+
+module Blit_bigstring =
+struct
+  type t = bigstring
+
+  let blit src src_idx dst dst_idx len =
+    let src = Array1.sub src src_idx len in
+    let dst = Array1.sub dst dst_idx len in
+    Memcpy.memcpy_bigstring src dst len src_idx dst_idx
+
+  let blit_string src src_idx dst dst_idx len =
+    assert (src_idx + len <= String.length src);
+    assert (dst_idx + len <= Array1.dim dst);
+
+    let idx = ref 0 in
+
+    while !idx < len do
+      Array1.set dst (dst_idx + !idx) (String.get src (src_idx + !idx));
+      incr idx;
+    done
+end
+
+module RW_ext = Make(Blit_bigstring)
+
+let to_rw (type a) (v : a RO.t) : a RW.t = match v with
+  | RO.String v -> RW.Bytes (Bytes.unsafe_of_string v)
+  | RO.Bigstring v -> RW.Bigstring v
+
+let to_ro (type a) (v : a RW.t) : a RO.t = match v with
+  | RW.Bytes v -> RO.String (Bytes.unsafe_to_string v)
+  | RW.Bigstring v -> RO.Bigstring v

--- a/lib/decompress_common.mli
+++ b/lib/decompress_common.mli
@@ -27,8 +27,8 @@ sig
   val to_string : t -> string
 end
 
-type normal
-type fast
+type normal = [ `Normal ]
+type fast   = [ `Fast ]
 
 module RO :
 sig

--- a/lib/decompress_common.mli
+++ b/lib/decompress_common.mli
@@ -1,18 +1,88 @@
-module ExtString :
+module type BLIT =
 sig
-  include (module type of String)
+  type t
+
+  val blit : t -> int -> t -> int -> int -> unit
+  val blit_string : string -> int -> t -> int -> int -> unit
 end
 
-module ExtBytes :
-sig
-  type i = String.t
+open Bigarray
 
-  include (module type of Bytes)
+type bigstring = (char, int8_unsigned_elt, c_layout) Array1.t
+
+module Bigstring :
+sig
+  type t = bigstring
+
+  val length : t -> int
+  val create : int -> t
+
+  val get : t -> int -> char
+  val set : t -> int -> char -> unit
+  val sub : t -> int -> int -> t
 
   val get_u16 : t -> int -> int
   val get_u64 : t -> int -> int64
 
-  val iblit   : i -> int -> t -> int -> int -> unit
-
-  val of_input  : i -> t
+  val to_string : t -> string
 end
+
+type normal
+type fast
+
+module RO :
+sig
+  type 'a t =
+    | String : string -> normal t
+    | Bigstring : bigstring -> fast t
+
+  val from_string    : string -> normal t
+  val from_bigstring : bigstring -> fast t
+
+  val length         : 'a t -> int
+  val get            : 'a t -> int -> char
+  val get_u16        : 'a t -> int -> int
+  val get_u64        : 'a t -> int -> int64
+  val sub            : 'a t -> int -> int -> 'a t
+
+  val pp             : Format.formatter -> 'a t -> unit
+end
+
+module RW :
+sig
+  type 'a t =
+    | Bytes     : bytes -> normal t
+    | Bigstring : bigstring -> fast t
+
+  val from_bytes     : bytes -> normal t
+  val from_bigstring : bigstring -> fast t
+
+  val create_fast    : int -> fast t
+  val create_normal  : int -> normal t
+  val create_by      : 'a t -> int -> 'a t
+
+  val length         : 'a t -> int
+  val get            : 'a t -> int -> char
+  val set            : 'a t -> int -> char -> unit
+  val get_u16        : 'a t -> int -> int
+  val get_u64        : 'a t -> int -> int64
+
+  val sub_ro         : 'a t -> int -> int -> 'a RO.t
+
+  val fill           : 'a t -> int -> int -> char -> unit
+end
+
+module Make (Blit : BLIT with type t = bigstring) :
+sig
+  include (module type of RW)
+
+  val blit           : 'a t -> int -> 'a t -> int -> int -> unit
+  val blit_ro        : 'a RO.t -> int -> 'a t -> int -> int -> unit
+  val blit_string    : string -> int -> 'a t -> int -> int -> unit
+end with type 'a t = 'a RW.t
+
+module Blit_bigstring : BLIT with type t = bigstring
+module RW_ext         : module type of Make (Blit_bigstring)
+
+val to_rw : 'a RO.t -> 'a RW.t
+val to_ro : 'a RW.t -> 'a RO.t

--- a/lib/decompress_deflate.ml
+++ b/lib/decompress_deflate.ml
@@ -1,4 +1,5 @@
 open Decompress_tables
+open Decompress_common
 
 module type S =
 sig
@@ -17,30 +18,6 @@ sig
   val compress : ?window_bits:int -> ?level:int -> src -> dst -> (src -> bool * int) -> (dst -> int -> int) -> unit
 end
 
-module type INPUT =
-sig
-  type t
-
-  val length : t -> int
-  val get    : t -> int -> char
-end
-
-module type OUTPUT =
-sig
-  type t
-  type i
-
-  val create   : int -> t
-  val length   : t -> int
-  val blit     : t -> int -> t -> int -> int -> unit
-  val set      : t -> int -> char -> unit
-  val get      : t -> int -> char
-  val get_u16  : t -> int -> int
-  val get_u64  : t -> int -> int64
-  val sub      : t -> int -> int -> t
-  val of_input : i -> t
-end
-
 let binary_of_byte ?(size = 8) byte =
   if byte < 0 then invalid_arg "binary_of_byte" else
   if byte = 0 then String.make size '0' else
@@ -51,664 +28,762 @@ let binary_of_byte ?(size = 8) byte =
     let l = aux [] byte in
     String.make (size - List.length l) '0' ^ String.concat "" (aux [] byte)
 
-module Make (I : INPUT) (O : OUTPUT with type i = I.t) : S
-  with type src = I.t
-   and type dst = O.t =
-struct
-  let () = [%debug Logs.set_level (Some Logs.Debug)]
-  let () = [%debug Logs.set_reporter (Logs_fmt.reporter ())]
+let () = [%debug Logs.set_level (Some Logs.Debug)]
+let () = [%debug Logs.set_reporter (Logs_fmt.reporter ())]
 
-  exception Expected_data
+exception Expected_data
 
-  module Adler32 = Decompress_adler32.Make(Char)(struct type elt = char include I end)
-  module Lz77    = Decompress_lz77.Make(O)
-  module Tree    = Decompress_tree
-  module Huffman = Decompress_huffman
+module Adler32 = Decompress_adler32
+module Lz77    = Decompress_lz77
+module Tree    = Decompress_tree
+module Huffman = Decompress_huffman
 
-  type mode =
-    | Dynamic of Lz77.state
-    | Static  of Lz77.state
-    | Flat    of O.t * int * int
-      (* buffer * real size * window bits (to avoid the recompute) *)
+type 'a mode =
+  | Dynamic of 'a Lz77.state
+  | Static  of 'a Lz77.state
+  | Flat    of 'a RW.t * int * int
+    (* buffer * real size * window bits (to avoid the recompute) *)
 
-  let binary_of_mode = function
-    | Dynamic _ -> 2
-    | Static _  -> 1
-    | Flat _    -> 0
+let binary_of_mode = function
+  | Dynamic _ -> 2
+  | Static _  -> 1
+  | Flat _    -> 0
 
-  let mode_is_empty = function
-    | Flat (_, size, _) -> size = 0
-    | Static lz77 | Dynamic lz77 -> Lz77.is_empty lz77
+let mode_is_empty = function
+  | Flat (_, size, _) -> size = 0
+  | Static lz77 | Dynamic lz77 -> Lz77.is_empty lz77
 
-  let window_bits_of_mode = function
-    | Static lz77 | Dynamic lz77 -> Lz77.window_bits lz77
-    | Flat (buffer, _, window_bits) -> window_bits
+let window_bits_of_mode = function
+  | Static lz77 | Dynamic lz77 -> Lz77.window_bits lz77
+  | Flat (buffer, _, window_bits) -> window_bits
 
-  let dynamic ~level window_bits = Dynamic (Lz77.make ~window_bits ~level ())
-  let static  ~level window_bits = Static (Lz77.make ~window_bits ~level ())
-  let flat                    () = Flat (O.create 0xFFFF, 0, 0xFFFF)
+let dynamic ~level window_bits proof = Dynamic (Lz77.make ~window_bits ~level proof)
+let static  ~level window_bits proof = Static (Lz77.make ~window_bits ~level proof)
+let flat                       proof = Flat (RW.create_by proof 0xFFFF, 0, 0xFFFF)
 
-  type flush =
-    | Sync_flush
-    (** It performs the following tasks:
-     *  * If there is some buffered but not yet compressed data, then this data
-     *    is compressed into one or several blocks (the type for each block will
-     *    depend on the amount and nature of data).
-     *  * A new type 0 block with empty contents is appended.
-     *
-     *  A type 0 block with empty contents consists of:
-     *  * the three-bit block header;
-     *  * 0 to 7 bits equal to zero, to achieve byte alignment;
-     *  * the four-byte sequence 00 00 FF FF.
-     *)
-    | Partial_flush
-    (** After. *)
-    | Full_flush
-    (** The "full flush" (with Z_FULL_FLUSH) is a variant of the sync flush. The
-     *  difference lies in the LZ77 step. Recall that the LZ77 algorithm
-     *  replaces some sequences of characters by references to an identical
-     *  sequence occurring somewhere in the previous uncompressed data (the
-     *  backward distance is up to 32 kB in DEFLATE). This can be viewed in the
-     *  following way: the previous data bytes collectively represent a
-     *  dictionary of sequences, which the LZ77 unit can use by including
-     *  symbolic references, when such a sequence is encountered.
-     *
-     *  At the very beginning of the stream, the dictionary is empty (it can be
-     *  set to arbitrary data, but the deflater and the inflater must use the
-     *  same preset dictionary, which is a convention outside the scope of this
-     *  document). It is then filled with the first 32 kB of data. As more data
-     *  is processed, the dictionary is constantly updated, and entries which
-     *  become too old are dropped. The full flush is a sync flush where the
-     *  dictionary is emptied: after a full flush, the deflater will refrain
-     *  from using copy symbols which reference sequences appearing before the
-     *  flush point.
-     *
-     *  From the inflater point of view, no special treatment of full flushes is
-     *  needed. The difference between a sync flush and a full flush alters only
-     *  the way the deflater selects symbols. A full flush degrades the
-     *  compression efficiency since it removes sequence sharing opportunities
-     *  for the next 32 kB of data; however, this degradation is very slight if
-     *  full flushes are applied only rarely with regards to the 32 kB window
-     *  size, e.g. every 1 MB or so. Full flushes are handy for damage recovery:
-     *
-     *  * a full flush is also a sync flush, which includes the very specific
-     *    and highly recognizable 00 00 FF FF pattern;
-     *  * byte alignment is restored by a full flush;
-     *  * inflation can take over from a full flush point without any knowledge
-     *    of the previous bytes.
-     *
-     *  It is therefore recommended to include occasional full flushes in long
-     *  streams of data, except if the outer protocol makes it useless (e.g. TLS
-     *  and SSH are security protocols which apply cryptographic integrity
-     *  checks which detect alterations with a very high probability, and it is
-     *  specified that they MUST NOT try to recover from damage, since such
-     *  damage could be malicious).)
-     *)
+type flush =
+  | Sync_flush
+  | Partial_flush
+  | Full_flush
 
-  let fixed_huffman_length_table =
-    Array.init 288
-      (fun n ->
-         if n < 144 then (n + 0x030, 8)
-         else if n < 256 then (n - 144 + 0x190, 9)
-         else if n < 280 then (n - 256 + 0x000, 7)
-         else (n - 280 + 0x0C0, 8))
+let fixed_huffman_length_table =
+  Array.init 288
+    (fun n ->
+       if n < 144 then (n + 0x030, 8)
+       else if n < 256 then (n - 144 + 0x190, 9)
+       else if n < 280 then (n - 256 + 0x000, 7)
+       else (n - 280 + 0x0C0, 8))
 
-  type src = I.t
-  type dst = O.t
+type ('i, 'o) t =
+  {
+    src               : 'i RO.t;
+    dst               : 'o RW.t;
 
-  type t =
-    {
-      src               : src;
-      dst               : dst;
+    window_bits       : int;
 
-      window_bits       : int;
+    mutable last      : bool;
+    mutable hold      : int;
+    mutable bits      : int;
 
-      mutable last      : bool;
-      mutable hold      : int;
-      mutable bits      : int;
+    mutable outpos    : int;
+    mutable needed    : int;
 
-      mutable outpos    : int;
-      mutable needed    : int;
+    mutable inpos     : int;
+    mutable available : int;
 
-      mutable inpos     : int;
-      mutable available : int;
+    mutable i         : int;
+    mutable i_max     : int;
 
-      mutable i         : int;
-      mutable i_max     : int;
+    mutable crc       : Adler32.t;
+    mutable mode      : 'i mode;
 
-      mutable crc       : Adler32.t;
-      mutable mode      : mode;
+    mutable flush     : flush option;
+    mutable lock      : bool;
 
-      mutable flush     : flush option;
-      mutable lock      : bool;
+    mutable k         : ('i, 'o) t -> state;
+  }
+and state =
+  | Ok | Flush | Wait | Error
 
-      mutable k         : t -> [ `Ok | `Flush | `Error | `Wait ];
-    }
+type writing =
+  [ `Length
+  | `Extra_length
+  | `Dist
+  | `Extra_dist ]
 
-  type writing =
-    [ `Length
-    | `Extra_length
-    | `Dist
-    | `Extra_dist ]
+let put_byte deflater byte =
+  [%debug Logs.debug @@ fun m -> m "put one byte: 0x%02x" byte];
 
-  let put_byte deflater byte =
-    [%debug Logs.debug @@ fun m -> m "put one byte: 0x%02x" byte];
+  RW.set
+    deflater.dst
+    deflater.outpos
+    (byte |> Char.unsafe_chr); (* XXX: unsafe is mandatory *)
+  deflater.needed <- deflater.needed - 1;
+  deflater.outpos <- deflater.outpos + 1
 
-    O.set
-      deflater.dst
-      deflater.outpos
-      (byte |> Char.unsafe_chr); (* XXX: unsafe is mandatory *)
-    deflater.needed <- deflater.needed - 1;
-    deflater.outpos <- deflater.outpos + 1
+let put_short deflater short =
+  put_byte deflater (short land 0xFF);
+  put_byte deflater (short lsr 8 land 0xFF)
 
-  let put_short deflater short =
-    put_byte deflater (short land 0xFF);
-    put_byte deflater (short lsr 8 land 0xFF)
+let read_byte deflater =
+  if deflater.available - deflater.inpos > 0
+  then begin
+    let code = Char.code @@ RO.get deflater.src deflater.inpos in
+    [%debug Logs.debug @@ fun m -> m "read one byte: 0x%02x" code];
+    deflater.inpos <- deflater.inpos + 1;
+    code
+  end else raise Expected_data
 
-  let read_byte deflater =
-    if deflater.available - deflater.inpos > 0
-    then begin
-      let code = I.get deflater.src deflater.inpos |> Char.code in
-      [%debug Logs.debug @@ fun m -> m "read one byte: 0x%02x" code];
-      deflater.inpos <- deflater.inpos + 1;
-      code
-    end else raise Expected_data
+let put_short_msb deflater short =
+  put_byte deflater (short lsr 8 land 0xFF);
+  put_byte deflater (short land 0xFF)
 
-  let put_short_msb deflater short =
-    put_byte deflater (short lsr 8 land 0xFF);
-    put_byte deflater (short land 0xFF)
+let add_bits deflater code length =
+  if deflater.bits > 16 - length
+  then begin
+    deflater.hold <- deflater.hold lor (code lsl deflater.bits);
+    put_short deflater deflater.hold;
+    deflater.hold <- code lsr (16 - deflater.bits);
+    deflater.bits <- deflater.bits + (length - 16)
+  end else begin
+    deflater.hold <- deflater.hold lor (code lsl deflater.bits);
+    deflater.bits <- deflater.bits + length
+  end
 
-  let add_bits deflater code length =
-    if deflater.bits > 16 - length
-    then begin
-      deflater.hold <- deflater.hold lor (code lsl deflater.bits);
-      put_short deflater deflater.hold;
-      deflater.hold <- code lsr (16 - deflater.bits);
-      deflater.bits <- deflater.bits + (length - 16)
-    end else begin
-      deflater.hold <- deflater.hold lor (code lsl deflater.bits);
-      deflater.bits <- deflater.bits + length
-    end
+let add_bit deflater value =
+  add_bits deflater (if value then 1 else 0) 1
 
-  let add_bit deflater value =
-    add_bits deflater (if value then 1 else 0) 1
-
-  let flush deflater =
-    if deflater.bits = 16
-    then begin
-      put_short deflater deflater.hold;
-      deflater.hold <- 0;
-      deflater.bits <- 0
-    end else if deflater.bits >= 8 then begin
-      put_byte deflater (deflater.hold land 0xFF);
-      deflater.hold <- deflater.hold lsr 8;
-      deflater.bits <- deflater.bits - 8
-    end else ()
-
-  let align deflater =
-    if deflater.bits > 8
-    then begin
-      [%debug Logs.debug @@ fun m -> m "we have a data pending: %02x" deflater.hold];
-      put_short deflater deflater.hold
-    end else if deflater.bits > 0
-    then begin
-      [%debug Logs.debug @@ fun m -> m "we have a data pending: %02x" deflater.hold];
-      put_byte deflater (deflater.hold land 0xFF)
-    end;
-
+let flush deflater =
+  if deflater.bits = 16
+  then begin
+    put_short deflater deflater.hold;
     deflater.hold <- 0;
     deflater.bits <- 0
+  end else if deflater.bits >= 8 then begin
+    put_byte deflater (deflater.hold land 0xFF);
+    deflater.hold <- deflater.hold lsr 8;
+    deflater.bits <- deflater.bits - 8
+  end else ()
 
-  let put_bytes deflater ?(size = deflater.needed) bytes =
-    if deflater.bits <> 0 then flush deflater;
-    O.blit
-      bytes deflater.i
-      deflater.dst deflater.outpos
-      (O.length bytes);
-    deflater.needed <- deflater.needed - (O.length bytes);
-    deflater.outpos <- deflater.outpos + (O.length bytes)
+let align deflater =
+  if deflater.bits > 8
+  then begin
+    [%debug Logs.debug @@ fun m -> m "we have a data pending: %02x" deflater.hold];
+    put_short deflater deflater.hold
+  end else if deflater.bits > 0
+  then begin
+    [%debug Logs.debug @@ fun m -> m "we have a data pending: %02x" deflater.hold];
+    put_byte deflater (deflater.hold land 0xFF)
+  end;
 
-  exception OK
-  exception Avoid
+  deflater.hold <- 0;
+  deflater.bits <- 0
 
-  let get_tree_symbols hlit lit_len_lengths hdist dist_lengths =
-    let src = Array.make (hlit + hdist) 0 in
-    let result = Array.make (286 + 30) 0 in
-    let freqs = Array.make 19 0 in
+let put_bytes deflater ?(size = deflater.needed) bytes =
+  if deflater.bits <> 0 then flush deflater;
+  RW_ext.blit
+    bytes deflater.i
+    deflater.dst deflater.outpos
+    (RW.length bytes);
+  deflater.needed <- deflater.needed - (RW.length bytes);
+  deflater.outpos <- deflater.outpos + (RW.length bytes)
 
-    for i = 0 to hlit - 1 do src.(i) <- lit_len_lengths.(i) done;
-    for i = hlit to hlit + hdist - 1 do src.(i) <- dist_lengths.(i - hlit) done;
+exception OK
+exception Avoid
 
-    let n_result = ref 0 in
-    let i = ref 0 in
-    let l = Array.length src in
+let get_tree_symbols hlit lit_len_lengths hdist dist_lengths =
+  let src    = Array.make (hlit + hdist) 0 in
+  let result = Array.make (286 + 30) 0 in
+  let freqs  = Array.make 19 0 in
 
-    while !i < l do
-      let j = ref 1 in
+  for i = 0 to hlit - 1 do src.(i) <- lit_len_lengths.(i) done;
+  for i = hlit to hlit + hdist - 1 do src.(i) <- dist_lengths.(i - hlit) done;
 
-      while !i + !j < l && src.(!i + !j) = src.(!i)
-      do incr j done;
+  let n_result = ref 0 in
+  let i = ref 0 in
+  let l = Array.length src in
 
-      let run_length = ref !j in
+  while !i < l do
+    let j = ref 1 in
 
-      if src.(!i) = 0
+    while !i + !j < l && src.(!i + !j) = src.(!i)
+    do incr j done;
+
+    let run_length = ref !j in
+
+    if src.(!i) = 0
+    then
+      if !run_length < 3
       then
+        while !run_length > 0 do
+          result.(!n_result) <- 0;
+          incr n_result;
+          freqs.(0) <- freqs.(0) + 1;
+          decr run_length;
+        done
+      else
+        while !run_length > 0 do
+          let rpt = ref (if !run_length < 138 then !run_length else 138) in
+
+          if !rpt > !run_length - 3 && !rpt < !run_length
+          then rpt := !run_length - 3;
+
+          if !rpt <= 10
+          then begin
+            result.(!n_result) <- 17;
+            incr n_result;
+            result.(!n_result) <- !rpt - 3;
+            incr n_result;
+            freqs.(17) <- freqs.(17) + 1;
+          end else begin
+            result.(!n_result) <- 18;
+            incr n_result;
+            result.(!n_result) <- !rpt - 11;
+            incr n_result;
+            freqs.(18) <- freqs.(18) + 1;
+          end;
+
+          run_length := !run_length - !rpt;
+        done
+    else
+      begin
+        result.(!n_result) <- src.(!i);
+        incr n_result;
+        freqs.(src.(!i)) <- freqs.(src.(!i)) + 1;
+        decr run_length;
+
         if !run_length < 3
         then
           while !run_length > 0 do
-            result.(!n_result) <- 0;
+            result.(!n_result) <- src.(!i);
             incr n_result;
-            freqs.(0) <- freqs.(0) + 1;
+            freqs.(src.(!i)) <- freqs.(src.(!i)) + 1;
             decr run_length;
           done
         else
           while !run_length > 0 do
-            let rpt = ref (if !run_length < 138 then !run_length else 138) in
+            let rpt = ref (if !run_length < 6 then !run_length else 6) in
 
             if !rpt > !run_length - 3 && !rpt < !run_length
             then rpt := !run_length - 3;
 
-            if !rpt <= 10
-            then begin
-              result.(!n_result) <- 17;
-              incr n_result;
-              result.(!n_result) <- !rpt - 3;
-              incr n_result;
-              freqs.(17) <- freqs.(17) + 1;
-            end else begin
-              result.(!n_result) <- 18;
-              incr n_result;
-              result.(!n_result) <- !rpt - 11;
-              incr n_result;
-              freqs.(18) <- freqs.(18) + 1;
-            end;
+            result.(!n_result) <- 16;
+            incr n_result;
+            result.(!n_result) <- !rpt - 3;
+            incr n_result;
+            freqs.(16) <- freqs.(16) + 1;
 
             run_length := !run_length - !rpt;
           done
-      else
-        begin
-          result.(!n_result) <- src.(!i);
-          incr n_result;
-          freqs.(src.(!i)) <- freqs.(src.(!i)) + 1;
-          decr run_length;
-
-          if !run_length < 3
-          then
-            while !run_length > 0 do
-              result.(!n_result) <- src.(!i);
-              incr n_result;
-              freqs.(src.(!i)) <- freqs.(src.(!i)) + 1;
-              decr run_length;
-            done
-          else
-            while !run_length > 0 do
-              let rpt = ref (if !run_length < 6 then !run_length else 6) in
-
-              if !rpt > !run_length - 3 && !rpt < !run_length
-              then rpt := !run_length - 3;
-
-              result.(!n_result) <- 16;
-              incr n_result;
-              result.(!n_result) <- !rpt - 3;
-              incr n_result;
-              freqs.(16) <- freqs.(16) + 1;
-
-              run_length := !run_length - !rpt;
-            done
-        end;
-
-      i := !i + !j;
-    done;
-
-    Array.sub result 0 !n_result, freqs
-
-  exception No_more_input
-
-  let rec make ?(window_bits = 15) ?(level = 4) src dst =
-    let mode = match level with
-      | 0 -> flat ()
-      | 1 -> static ~level window_bits
-      | 2 -> static ~level window_bits
-      | 3 -> static ~level window_bits
-      | 4 -> dynamic ~level window_bits
-      | 5 -> dynamic ~level window_bits
-      | 6 -> dynamic ~level window_bits
-      | 7 -> dynamic ~level window_bits
-      | 8 -> dynamic ~level window_bits
-      | 9 -> dynamic ~level window_bits
-      | _ -> raise (Invalid_argument "Deflate.make: invalid level")
-    in
-    { src
-    ; dst
-
-    ; window_bits
-
-    ; last            = false
-    ; hold            = 0
-    ; bits            = 0
-
-    ; outpos          = 0
-    ; needed          = 0
-
-    ; inpos           = 0
-    ; available       = 0
-
-    ; i               = 0
-    ; i_max           = 0
-
-    ; crc             = Adler32.init ()
-    ; mode
-
-    ; flush           = None
-    ; lock            = false
-
-    ; k               = header }
-
-  and eval deflater = deflater.k deflater
-
-  and header deflater =
-    [%debug Logs.debug @@ fun m -> m "state: header"];
-
-    let rec write_header0 header deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_header0"];
-
-      if deflater.needed > 0
-      then begin
-        put_byte deflater (header lsr 8);
-        deflater.k <- write_header1 header;
-
-        eval deflater
-      end else `Flush
-
-    and write_header1 header deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_header1"];
-      [%debug Logs.debug @@ fun m -> m "we need 1 byte(s) and we have %d byte(s)" deflater.needed];
-
-      if deflater.needed > 0
-      then begin
-        put_byte deflater (header land 0xFF);
-        deflater.k <- read;
-
-        eval deflater
-      end else begin
-        [%debug Logs.debug @@ fun m -> m "we need to flush output to write 1 bytes"];
-        `Flush
-      end
-    in
-
-    let header = (8 + ((deflater.window_bits - 8) lsl 4)) lsl 8 in
-    (* XXX: CM = 8 and CINFO = 7 for 32K window
-     * size and denotes the "deflate" compression
-     * method *)
-    let header = header lor (0x4 lsl 5) in (* XXX: FDICT = 0 and FLEVEL = 2,
-                                            * we use a default algorithm *)
-    let header = header + (31 - (header mod 31)) in
-
-    deflater.k <- write_header0 header;
-
-    if deflater.needed > 1
-    then eval deflater
-    else `Flush
-
-  and read deflater =
-    [%debug Logs.debug @@ fun m -> m "state: read (last = %b)" deflater.last];
-
-    let rec aux deflater =
-      let new_mode, read = match deflater.mode with
-        | Flat (buffer, real_size, window_bits) ->
-          let len = min (0xFFFF - real_size) deflater.available in
-
-          [%debug Logs.debug @@ fun m -> m
-            "read and write flat data (size: %d byte(s))" len];
-
-          (* write flat data to output buffer *)
-          let s = O.of_input deflater.src in
-          let i = ref 0 in
-
-          while !i < len
-          do
-            O.set buffer (real_size + !i) (O.get s (deflater.inpos + !i));
-            incr i;
-          done;
-
-          (* update CRC *)
-          deflater.crc <- Adler32.update deflater.src deflater.inpos len deflater.crc;
-
-          [%debug Logs.debug @@ fun m -> m "the size of new buffer of flat is %d" (real_size + len)];
-
-          Flat (buffer, real_size + len, window_bits), len
-
-        | Dynamic lz77 ->
-          [%debug Logs.debug @@ fun m -> m "read input data and complete Lz77 dictionary for a dynamic Huffman tree"];
-
-          (* complete Lz77 dictionary *)
-          Lz77.atomic_compress lz77 deflater.src
-            deflater.inpos deflater.available;
-
-          (* update CRC *)
-          deflater.crc <-
-            Adler32.update deflater.src
-              deflater.inpos
-              deflater.available
-              deflater.crc;
-
-          Dynamic lz77, deflater.available
-
-        | Static lz77 ->
-          [%debug Logs.debug @@ fun m -> m "read input data and complete Lz77 dictionary for a static Huffman tree"];
-
-          (* complete Lz77 dictionary *)
-          Lz77.atomic_compress lz77 deflater.src
-            deflater.inpos deflater.available;
-
-          (* update CRC *)
-          deflater.crc <-
-            Adler32.update deflater.src
-              deflater.inpos
-              deflater.available
-              deflater.crc;
-
-          Static lz77, deflater.available
-      in
-
-      deflater.inpos <- deflater.inpos + read;
-      deflater.available <- deflater.available - read;
-      deflater.mode <- new_mode;
-      deflater.k <- flushing_method
-    in
-
-    if deflater.available > 0 || deflater.last = true
-    then begin
-      aux deflater;
-      eval deflater
-    end else `Wait
-
-  and flushing_method deflater =
-    let new_k = match deflater.flush, deflater.last with
-      (* if we have [Some x], user expect a new compute, otherwise we can
-         continue *)
-      | Some Sync_flush, false    -> sync_flush
-      | Some Partial_flush, false -> sync_flush
-      | Some Full_flush, false    -> sync_flush
-      | _, true                   ->
-        [%debug Logs.debug @@ fun m -> m "we stop compute, the last flag is send"];
-        end_flush
-      | None, false           ->
-        [%debug Logs.debug @@ fun m -> m "we continue to read the block"];
-
-        match deflater.mode with
-        | Flat (buffer, real_size, window_bits) when real_size = 0xFFFF ->
-          [%debug Logs.debug @@ fun m -> m "we stop the flat block and create a new"];
-
-         sync_flush
-        | _ -> read
-    in
-
-    deflater.k <- new_k;
-
-    eval deflater
-
-  and sync_flush deflater =
-    [%debug Logs.debug @@ fun m -> m "state: sync_flush"];
-
-    deflater.k <-
-      if mode_is_empty deflater.mode
-      then empty_block
-      else new_block empty_block false;
-
-    eval deflater
-
-  and end_flush deflater =
-    [%debug Logs.debug @@ fun m -> m "state: end_flush"];
-
-    deflater.k <- new_block (align_writing write_crc1) true;
-
-    eval deflater
-
-  and new_block after_block is_last_block deflater =
-    [%debug Logs.debug @@ fun m -> m "state: new_block"];
-
-    if deflater.needed > 1
-    then begin
-      add_bit deflater is_last_block;
-      deflater.k <- write_block after_block;
-
-      eval deflater
-    end else `Flush
-
-  and empty_block deflater =
-    [%debug Logs.debug @@ fun m -> m "state: empty block"];
-
-    let rec write_last_flag deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_last_flag"];
-
-      if deflater.needed > 1
-      then begin
-        add_bit deflater deflater.last;
-        deflater.k <- write_flat_block;
-
-        eval deflater
-      end else `Flush
-
-    and write_flat_block deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_flat_block"];
-
-      if deflater.needed > 1
-      then begin
-        add_bits deflater 0 2; (* XXX: 0 is the type of [Flat] block. *)
-        deflater.k <- align_writing write_empty_block;
-
-        eval deflater
-      end else `Flush
-
-    and write_empty_block deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_empty_block"];
-
-      let rec write_len deflater =
-        [%debug Logs.debug @@ fun m -> m "state: write_len"];
-
-        if deflater.needed > 1
-        then begin
-          put_short deflater 0x0000;
-          deflater.k <- write_nlen;
-
-          eval deflater
-        end else `Flush
-
-      and write_nlen deflater =
-        [%debug Logs.debug @@ fun m -> m "state: write_nlen"];
-
-        if deflater.needed > 1
-        then begin
-          put_short deflater 0xFFFF;
-          deflater.k <- if deflater.last then write_crc1 else read;
-
-          eval deflater
-        end else `Flush
-      in
-
-      deflater.k <- write_len;
-      eval deflater
-    in
-
-    deflater.k <- write_last_flag;
-    eval deflater
-
-  and write_block after_block deflater =
-    [%debug Logs.debug @@ fun m -> m "state: block"];
-
-    if deflater.needed > 1
-    then begin
-      add_bits deflater (binary_of_mode deflater.mode) 2;
-
-      deflater.k <- begin match deflater.mode with
-        | Flat (buffer, real_size, _) -> align_writing (len after_block real_size buffer)
-        | Dynamic lz77                -> initialize_dynamic after_block (Lz77.finish lz77)
-        | Static lz77                 -> initialize_fixed after_block (Lz77.finish lz77)
       end;
 
-      eval deflater
-    end else `Flush
+    i := !i + !j;
+  done;
 
-  and len after_block len buffer deflater =
-    [%debug Logs.debug @@ fun m -> m "state: len"];
+  Array.sub result 0 !n_result, freqs
 
-    if deflater.needed > 1
-    then begin
-      put_short deflater len;
-      deflater.k <- nlen after_block len buffer;
+exception No_more_input
 
-      eval deflater
-    end else `Flush
+let rec make ?(window_bits = 15) ?(level = 4) src dst =
+  let mode = match level with
+    | 0 -> flat dst
+    | 1 -> static ~level window_bits dst
+    | 2 -> static ~level window_bits dst
+    | 3 -> static ~level window_bits dst
+    | 4 -> dynamic ~level window_bits dst
+    | 5 -> dynamic ~level window_bits dst
+    | 6 -> dynamic ~level window_bits dst
+    | 7 -> dynamic ~level window_bits dst
+    | 8 -> dynamic ~level window_bits dst
+    | 9 -> dynamic ~level window_bits dst
+    | _ -> raise (Invalid_argument "Deflate.make: invalid level")
+  in
+  { src
+  ; dst
 
-  and nlen after_block len buffer deflater =
-    [%debug Logs.debug @@ fun m -> m "state: nlen"];
+  ; window_bits
 
-    if deflater.needed > 1
-    then begin
-      put_short deflater (lnot len);
+  ; last            = false
+  ; hold            = 0
+  ; bits            = 0
 
-      deflater.k <- write_flat after_block buffer;
-      deflater.i <- 0;
-      deflater.i_max <- len;
+  ; outpos          = 0
+  ; needed          = 0
 
-      eval deflater
-    end else `Flush
+  ; inpos           = 0
+  ; available       = 0
 
-  and write_flat after_block buffer deflater =
-    [%debug Logs.debug @@ fun m -> m "state: write_flat"];
+  ; i               = 0
+  ; i_max           = 0
 
-    let len = min (deflater.i_max - deflater.i) deflater.needed in
+  ; crc             = Adler32.default
+  ; mode
 
-    for i = 0 to len - 1
-    do put_byte deflater (Char.code @@ O.get buffer (deflater.i + i)) done;
+  ; flush           = None
+  ; lock            = false
 
-    deflater.i <- deflater.i + len;
+  ; k               = header }
 
-    [%debug Logs.debug @@ fun m -> m "we write %02d in flat block and the rest is %02d" len (deflater.i_max - deflater.i)];
+and eval deflater = deflater.k deflater
 
-    deflater.k <-
-      if deflater.i = deflater.i_max
-      then clear_flat after_block
-      else write_flat after_block buffer;
+and header deflater =
+  [%debug Logs.debug @@ fun m -> m "state: header"];
+
+  let rec write_header0 header deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_header0"];
 
     if deflater.needed > 0
-    then eval deflater
-    else `Flush
+    then begin
+      put_byte deflater (header lsr 8);
+      deflater.k <- write_header1 header;
 
-  and clear_flat after_block deflater =
-    deflater.mode <- flat ();
-    deflater.k <- after_block;
+      eval deflater
+    end else Flush
+
+  and write_header1 header deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_header1"];
+    [%debug Logs.debug @@ fun m -> m "we need 1 byte(s) and we have %d byte(s)" deflater.needed];
+
+    if deflater.needed > 0
+    then begin
+      put_byte deflater (header land 0xFF);
+      deflater.k <- read;
+
+      eval deflater
+    end else begin
+      [%debug Logs.debug @@ fun m -> m "we need to flush output to write 1 bytes"];
+      Flush
+    end
+  in
+
+  let header = (8 + ((deflater.window_bits - 8) lsl 4)) lsl 8 in
+  (* XXX: CM = 8 and CINFO = 7 for 32K window
+   * size and denotes the "deflate" compression
+   * method *)
+  let header = header lor (0x4 lsl 5) in (* XXX: FDICT = 0 and FLEVEL = 2,
+                                          * we use a default algorithm *)
+  let header = header + (31 - (header mod 31)) in
+
+  deflater.k <- write_header0 header;
+
+  if deflater.needed > 1
+  then eval deflater
+  else Flush
+
+and read deflater =
+  [%debug Logs.debug @@ fun m -> m "state: read (last = %b)" deflater.last];
+
+  let rec aux deflater =
+    let new_mode, read = match deflater.mode with
+      | Flat (buffer, real_size, window_bits) ->
+        let len = min (0xFFFF - real_size) deflater.available in
+
+        [%debug Logs.debug @@ fun m -> m
+          "read and write flat data (size: %d byte(s))" len];
+
+        RW_ext.blit_ro deflater.src deflater.inpos buffer real_size len;
+        deflater.crc <- Adler32.update deflater.src deflater.inpos len deflater.crc;
+
+        [%debug Logs.debug @@ fun m -> m "the size of new buffer of flat is %d" (real_size + len)];
+
+        Flat (buffer, real_size + len, window_bits), len
+
+      | Dynamic lz77 ->
+        [%debug Logs.debug @@ fun m -> m "read input data and complete Lz77 dictionary for a dynamic Huffman tree"];
+
+        (* complete Lz77 dictionary *)
+        Lz77.atomic_compress lz77 deflater.src
+          deflater.inpos deflater.available;
+
+        (* update CRC *)
+        deflater.crc <-
+          Adler32.update deflater.src
+            deflater.inpos
+            deflater.available
+            deflater.crc;
+
+        Dynamic lz77, deflater.available
+
+      | Static lz77 ->
+        [%debug Logs.debug @@ fun m -> m "read input data and complete Lz77 dictionary for a static Huffman tree"];
+
+        (* complete Lz77 dictionary *)
+        Lz77.atomic_compress lz77 deflater.src
+          deflater.inpos deflater.available;
+
+        (* update CRC *)
+        deflater.crc <-
+          Adler32.update deflater.src
+            deflater.inpos
+            deflater.available
+            deflater.crc;
+
+        Static lz77, deflater.available
+    in
+
+    deflater.inpos <- deflater.inpos + read;
+    deflater.available <- deflater.available - read;
+    deflater.mode <- new_mode;
+    deflater.k <- flushing_method
+  in
+
+  if deflater.available > 0 || deflater.last = true
+  then begin
+    aux deflater;
+    eval deflater
+  end else Wait
+
+and flushing_method deflater =
+  let new_k = match deflater.flush, deflater.last with
+    (* if we have [Some x], user expect a new compute, otherwise we can
+       continue *)
+    | Some Sync_flush, false    -> sync_flush
+    | Some Partial_flush, false -> sync_flush
+    | Some Full_flush, false    -> sync_flush
+    | _, true                   ->
+      [%debug Logs.debug @@ fun m -> m "we stop compute, the last flag is send"];
+      end_flush
+    | None, false           ->
+      [%debug Logs.debug @@ fun m -> m "we continue to read the block"];
+
+      match deflater.mode with
+      | Flat (buffer, real_size, window_bits) when real_size = 0xFFFF ->
+        [%debug Logs.debug @@ fun m -> m "we stop the flat block and create a new"];
+
+       sync_flush
+      | _ -> read
+  in
+
+  deflater.k <- new_k;
+
+  eval deflater
+
+and sync_flush deflater =
+  [%debug Logs.debug @@ fun m -> m "state: sync_flush"];
+
+  deflater.k <-
+    if mode_is_empty deflater.mode
+    then empty_block
+    else new_block empty_block false;
+
+  eval deflater
+
+and end_flush deflater =
+  [%debug Logs.debug @@ fun m -> m "state: end_flush"];
+
+  deflater.k <- new_block (align_writing write_crc1) true;
+
+  eval deflater
+
+and new_block after_block is_last_block deflater =
+  [%debug Logs.debug @@ fun m -> m "state: new_block"];
+
+  if deflater.needed > 1
+  then begin
+    add_bit deflater is_last_block;
+    deflater.k <- write_block after_block;
 
     eval deflater
+  end else Flush
 
-  and initialize_fixed after_block (lz77, _, _) deflater =
-    [%debug Logs.debug @@ fun m -> m "state: initialize_fixed"];
+and empty_block deflater =
+  [%debug Logs.debug @@ fun m -> m "state: empty block"];
 
-    let get_chr chr = _static_ltree.(chr) in
+  let rec write_last_flag deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_last_flag"];
+
+    if deflater.needed > 1
+    then begin
+      add_bit deflater deflater.last;
+      deflater.k <- write_flat_block;
+
+      eval deflater
+    end else Flush
+
+  and write_flat_block deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_flat_block"];
+
+    if deflater.needed > 1
+    then begin
+      add_bits deflater 0 2; (* XXX: 0 is the type of [Flat] block. *)
+      deflater.k <- align_writing write_empty_block;
+
+      eval deflater
+    end else Flush
+
+  and write_empty_block deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_empty_block"];
+
+    let rec write_len deflater =
+      [%debug Logs.debug @@ fun m -> m "state: write_len"];
+
+      if deflater.needed > 1
+      then begin
+        put_short deflater 0x0000;
+        deflater.k <- write_nlen;
+
+        eval deflater
+      end else Flush
+
+    and write_nlen deflater =
+      [%debug Logs.debug @@ fun m -> m "state: write_nlen"];
+
+      if deflater.needed > 1
+      then begin
+        put_short deflater 0xFFFF;
+        deflater.k <- if deflater.last then write_crc1 else read;
+
+        eval deflater
+      end else Flush
+    in
+
+    deflater.k <- write_len;
+    eval deflater
+  in
+
+  deflater.k <- write_last_flag;
+  eval deflater
+
+and write_block after_block deflater =
+  [%debug Logs.debug @@ fun m -> m "state: block"];
+
+  if deflater.needed > 1
+  then begin
+    add_bits deflater (binary_of_mode deflater.mode) 2;
+
+    deflater.k <- begin match deflater.mode with
+      | Flat (buffer, real_size, _) -> align_writing (len after_block real_size buffer)
+      | Dynamic lz77                -> initialize_dynamic after_block (Lz77.finish lz77)
+      | Static lz77                 -> initialize_fixed after_block (Lz77.finish lz77)
+    end;
+
+    eval deflater
+  end else Flush
+
+and len after_block len buffer deflater =
+  [%debug Logs.debug @@ fun m -> m "state: len"];
+
+  if deflater.needed > 1
+  then begin
+    put_short deflater len;
+    deflater.k <- nlen after_block len buffer;
+
+    eval deflater
+  end else Flush
+
+and nlen after_block len buffer deflater =
+  [%debug Logs.debug @@ fun m -> m "state: nlen"];
+
+  if deflater.needed > 1
+  then begin
+    put_short deflater (lnot len);
+
+    deflater.k <- write_flat after_block buffer;
+    deflater.i <- 0;
+    deflater.i_max <- len;
+
+    eval deflater
+  end else Flush
+
+and write_flat after_block buffer deflater =
+  [%debug Logs.debug @@ fun m -> m "state: write_flat"];
+
+  let len = min (deflater.i_max - deflater.i) deflater.needed in
+
+  for i = 0 to len - 1
+  do put_byte deflater (Char.code @@ RW.get buffer (deflater.i + i)) done;
+
+  deflater.i <- deflater.i + len;
+
+  [%debug Logs.debug @@ fun m -> m "we write %02d in flat block and the rest is %02d" len (deflater.i_max - deflater.i)];
+
+  deflater.k <-
+    if deflater.i = deflater.i_max
+    then clear_flat after_block
+    else write_flat after_block buffer;
+
+  if deflater.needed > 0
+  then eval deflater
+  else Flush
+
+and clear_flat after_block deflater =
+  deflater.mode <- flat deflater.dst;
+  deflater.k <- after_block;
+
+  eval deflater
+
+and initialize_fixed after_block (lz77, _, _) deflater =
+  [%debug Logs.debug @@ fun m -> m "state: initialize_fixed"];
+
+  let get_chr chr = _static_ltree.(chr) in
+  let get_length length =
+    let code = _length.(length) in
+    _static_ltree.(code + 256 + 1)
+  in
+  let get_extra_length length =
+    let code = _length.(length) in
+    let extra_bits = _extra_lbits.(code) in
+
+    (length - _base_length.(code), extra_bits)
+  in
+  let get_dist dist =
+    let code = _distance dist in
+    _static_dtree.(code)
+  in
+  let get_extra_dist dist =
+    let code = _distance dist in
+    let extra_bits = _extra_dbits.(code) in
+
+    (dist - _base_dist.(code), extra_bits)
+  in
+
+  deflater.k <- write after_block
+      ~get_chr
+      ~get_length
+      ~get_extra_length
+      ~get_dist
+      ~get_extra_dist
+      lz77;
+
+  eval deflater
+
+and initialize_dynamic after_block (lz77, freqs_literal, freqs_distance) deflater =
+  [%debug Logs.debug @@ fun m -> m "state: initialize_dynamic"];
+
+  let trans_length = Array.make 19 0 in
+  let literal_length  = Tree.get_lengths freqs_literal 15 in
+  let literal_code    = Tree.get_codes_from_lengths literal_length in
+  let distance_length = Tree.get_lengths freqs_distance 7 in
+  let distance_code   = Tree.get_codes_from_lengths distance_length in
+
+  let hlit = ref 286 in
+  while !hlit > 257 && literal_length.(!hlit - 1) = 0 do decr hlit done;
+
+  let hdist = ref 30 in
+  while !hdist > 1 && distance_length.(!hdist - 1) = 0 do decr hdist done;
+
+  let tree_symbol, freqs_tree =
+    get_tree_symbols !hlit literal_length !hdist distance_length in
+
+  let tree_length = Tree.get_lengths freqs_tree 7 in
+
+  for i = 0 to 18
+  do trans_length.(i) <- tree_length.(hclen_order.(i)) done;
+
+  let hclen = ref 19 in
+  while !hclen > 4 && trans_length.(!hclen - 1) = 0 do decr hclen done;
+
+  let tree_code = Tree.get_codes_from_lengths tree_length in
+  let hlit  = !hlit in
+  let hdist = !hdist in
+  let hclen = !hclen in
+
+  let rec write_hlit deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_hlit"];
+
+    if deflater.needed > 1
+    then begin
+      add_bits deflater (hlit - 257) 5;
+      deflater.k <- write_hdist;
+
+      eval deflater
+    end else Flush
+
+  and write_hdist deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_hdist"];
+
+    if deflater.needed > 1
+    then begin
+      add_bits deflater (hdist - 1) 5;
+      deflater.k <- write_hclen;
+
+      eval deflater
+    end else Flush
+
+  and write_hclen deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_hclen"];
+
+    if deflater.needed > 1
+    then begin
+      add_bits deflater (hclen - 4) 4;
+
+      deflater.i <- 0;
+      deflater.i_max <- hclen;
+      deflater.k <- write_trans;
+
+      eval deflater
+    end else Flush
+
+  and write_trans deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_trans"];
+
+    if deflater.needed > 1
+    then begin
+      add_bits deflater trans_length.(deflater.i) 3;
+
+      deflater.i <- deflater.i + 1;
+      deflater.k <-
+        if deflater.i = deflater.i_max
+        then begin
+          deflater.i <- 0;
+          deflater.i_max <- Array.length tree_symbol;
+          write_symbols
+        end else write_trans;
+
+      eval deflater
+    end else Flush
+
+  and write_symbols deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_symbols"];
+
+    if deflater.needed > 1
+    then begin
+      let code = tree_symbol.(deflater.i) in
+
+      add_bits deflater tree_code.(code) tree_length.(code);
+
+      deflater.i <- deflater.i + 1;
+      deflater.k <-
+        if code >= 16
+        then write_symbols_extra code
+        else if deflater.i >= deflater.i_max
+        then dynamic_getter
+        else write_symbols;
+
+      eval deflater
+    end else Flush
+
+  and write_symbols_extra code deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_symbols"];
+
+    let bitlen = match code with
+      | 16 -> 2
+      | 17 -> 3
+      | 18 -> 7
+      | _ -> assert false
+    in
+
+    if deflater.needed > 1
+    then begin
+      add_bits deflater tree_symbol.(deflater.i) bitlen;
+
+      deflater.i <- deflater.i + 1;
+      deflater.k <-
+        if deflater.i >= deflater.i_max
+        then dynamic_getter
+        else write_symbols;
+
+      eval deflater
+    end else Flush
+
+  and dynamic_getter deflater =
+    [%debug Logs.debug @@ fun m -> m "state: dynamic_getter"];
+
+    let get_chr chr = literal_code.(chr), literal_length.(chr) in
     let get_length length =
       let code = _length.(length) in
-      _static_ltree.(code + 256 + 1)
+      literal_code.(code + 256 + 1),
+      literal_length.(code + 256 + 1)
     in
     let get_extra_length length =
       let code = _length.(length) in
@@ -718,7 +793,7 @@ struct
     in
     let get_dist dist =
       let code = _distance dist in
-      _static_dtree.(code)
+      distance_code.(code), distance_length.(code)
     in
     let get_extra_dist dist =
       let code = _distance dist in
@@ -736,360 +811,216 @@ struct
         lz77;
 
     eval deflater
+  in
 
-  and initialize_dynamic after_block (lz77, freqs_literal, freqs_distance) deflater =
-    [%debug Logs.debug @@ fun m -> m "state: initialize_dynamic"];
+  deflater.k <- write_hlit;
 
-    let trans_length = Array.make 19 0 in
-    let literal_length  = Tree.get_lengths freqs_literal 15 in
-    let literal_code    = Tree.get_codes_from_lengths literal_length in
-    let distance_length = Tree.get_lengths freqs_distance 7 in
-    let distance_code   = Tree.get_codes_from_lengths distance_length in
+  eval deflater
 
-    let hlit = ref 286 in
-    while !hlit > 257 && literal_length.(!hlit - 1) = 0 do decr hlit done;
+and write after_writing
+    ~get_chr
+    ~get_length
+    ~get_extra_length
+    ~get_dist
+    ~get_extra_dist
+    lz77 deflater =
+  [%debug Logs.debug @@ fun m -> m "state: write"];
 
-    let hdist = ref 30 in
-    while !hdist > 1 && distance_length.(!hdist - 1) = 0 do decr hdist done;
+  let write =
+    [%debug Logs.debug @@ fun m -> m "state: write"];
 
-    let tree_symbol, freqs_tree =
-      get_tree_symbols !hlit literal_length !hdist distance_length in
-
-    let tree_length = Tree.get_lengths freqs_tree 7 in
-
-    for i = 0 to 18
-    do trans_length.(i) <- tree_length.(hclen_order.(i)) done;
-
-    let hclen = ref 19 in
-    while !hclen > 4 && trans_length.(!hclen - 1) = 0 do decr hclen done;
-
-    let tree_code = Tree.get_codes_from_lengths tree_length in
-    let hlit  = !hlit in
-    let hdist = !hdist in
-    let hclen = !hclen in
-
-    let rec write_hlit deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_hlit"];
-
-      if deflater.needed > 1
-      then begin
-        add_bits deflater (hlit - 257) 5;
-        deflater.k <- write_hdist;
-
-        eval deflater
-      end else `Flush
-
-    and write_hdist deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_hdist"];
-
-      if deflater.needed > 1
-      then begin
-        add_bits deflater (hdist - 1) 5;
-        deflater.k <- write_hclen;
-
-        eval deflater
-      end else `Flush
-
-    and write_hclen deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_hclen"];
-
-      if deflater.needed > 1
-      then begin
-        add_bits deflater (hclen - 4) 4;
-
-        deflater.i <- 0;
-        deflater.i_max <- hclen;
-        deflater.k <- write_trans;
-
-        eval deflater
-      end else `Flush
-
-    and write_trans deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_trans"];
-
-      if deflater.needed > 1
-      then begin
-        add_bits deflater trans_length.(deflater.i) 3;
-
-        deflater.i <- deflater.i + 1;
-        deflater.k <-
-          if deflater.i = deflater.i_max
-          then begin
-            deflater.i <- 0;
-            deflater.i_max <- Array.length tree_symbol;
-            write_symbols
-          end else write_trans;
-
-        eval deflater
-      end else `Flush
-
-    and write_symbols deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_symbols"];
-
-      if deflater.needed > 1
-      then begin
-        let code = tree_symbol.(deflater.i) in
-
-        add_bits deflater tree_code.(code) tree_length.(code);
-
-        deflater.i <- deflater.i + 1;
-        deflater.k <-
-          if code >= 16
-          then write_symbols_extra code
-          else if deflater.i >= deflater.i_max
-          then dynamic_getter
-          else write_symbols;
-
-        eval deflater
-      end else `Flush
-
-    and write_symbols_extra code deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_symbols"];
-
-      let bitlen = match code with
-        | 16 -> 2
-        | 17 -> 3
-        | 18 -> 7
-        | _ -> assert false
-      in
-
-      if deflater.needed > 1
-      then begin
-        add_bits deflater tree_symbol.(deflater.i) bitlen;
-
-        deflater.i <- deflater.i + 1;
-        deflater.k <-
-          if deflater.i >= deflater.i_max
-          then dynamic_getter
-          else write_symbols;
-
-        eval deflater
-      end else `Flush
-
-    and dynamic_getter deflater =
-      [%debug Logs.debug @@ fun m -> m "state: dynamic_getter"];
-
-      let get_chr chr = literal_code.(chr), literal_length.(chr) in
-      let get_length length =
-        let code = _length.(length) in
-        literal_code.(code + 256 + 1),
-        literal_length.(code + 256 + 1)
-      in
-      let get_extra_length length =
-        let code = _length.(length) in
-        let extra_bits = _extra_lbits.(code) in
-
-        (length - _base_length.(code), extra_bits)
-      in
-      let get_dist dist =
-        let code = _distance dist in
-        distance_code.(code), distance_length.(code)
-      in
-      let get_extra_dist dist =
-        let code = _distance dist in
-        let extra_bits = _extra_dbits.(code) in
-
-        (dist - _base_dist.(code), extra_bits)
-      in
-
-      deflater.k <- write after_block
-          ~get_chr
-          ~get_length
-          ~get_extra_length
-          ~get_dist
-          ~get_extra_dist
-          lz77;
-
-      eval deflater
-    in
-
-    deflater.k <- write_hlit;
-
-    eval deflater
-
-  and write after_writing
+    write
+      after_writing
       ~get_chr
       ~get_length
       ~get_extra_length
       ~get_dist
       ~get_extra_dist
-      lz77 deflater =
-    [%debug Logs.debug @@ fun m -> m "state: write"];
+  in
+  let getter = function
+    | `Length            -> get_length
+    | `Extra_length      -> get_extra_length
+    | `Dist              -> get_dist
+    | `Extra_dist        -> get_extra_dist
+  in
+  let value (dist, length) = function
+    | `Length | `Extra_length -> length
+    | `Dist | `Extra_dist -> dist
+  in
+  let rec write_buffer data rest deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_buffer (iterator: %d, max: %d)" deflater.i deflater.i_max];
 
-    let write =
-      [%debug Logs.debug @@ fun m -> m "state: write"];
+    let i = ref deflater.i in
 
-      write
-        after_writing
-        ~get_chr
-        ~get_length
-        ~get_extra_length
-        ~get_dist
-        ~get_extra_dist
-    in
-    let getter = function
-      | `Length            -> get_length
-      | `Extra_length      -> get_extra_length
-      | `Dist              -> get_dist
-      | `Extra_dist        -> get_extra_dist
-    in
-    let value (dist, length) = function
-      | `Length | `Extra_length -> length
-      | `Dist | `Extra_dist -> dist
-    in
-    let rec write_buffer data rest deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_buffer (iterator: %d, max: %d)" deflater.i deflater.i_max];
+    while !i < deflater.i_max && deflater.needed > 1
+    do
+      [%debug Logs.debug @@ fun m -> m "we will write the literal %c (code = %d)"
+        (RO.get data !i) (RO.get data !i |> Char.code |> get_chr |> fst)];
 
-      let i = ref deflater.i in
+      let code, length = RO.get data !i |> Char.code |> get_chr in
 
-      while !i < deflater.i_max && deflater.needed > 1
-      do
-        [%debug Logs.debug @@ fun m -> m "we will write the literal %c (code = %d)"
-          (O.get data !i) (O.get data !i |> Char.code |> get_chr |> fst)];
+      add_bits deflater code length;
+      incr i
+    done;
 
-        let code, length = O.get data !i |> Char.code |> get_chr in
+    [%debug Logs.debug @@ fun m -> m "we write %d data(s)" !i];
 
-        add_bits deflater code length;
-        incr i
-      done;
+    deflater.i <- !i;
+    deflater.k <-
+      if deflater.i = deflater.i_max
+      then write rest
+      else write_buffer data rest;
 
-      [%debug Logs.debug @@ fun m -> m "we write %d data(s)" !i];
+    if deflater.needed > 1
+    then eval deflater
+    else Flush
+  in
+  let rec write_insert ?(writing = `Length) v rest deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_insert"];
 
-      deflater.i <- !i;
-      deflater.k <-
-        if deflater.i = deflater.i_max
-        then write rest
-        else write_buffer data rest;
+    if deflater.needed > 1
+    then begin
+      let c, l = (getter writing) (value v writing) in
+      add_bits deflater c l;
 
-      if deflater.needed > 1
-      then eval deflater
-      else `Flush
-    in
-    let rec write_insert ?(writing = `Length) v rest deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_insert"];
+      deflater.k <- (match writing with
+          | `Length       -> write_insert ~writing:`Extra_length v rest
+          | `Extra_length -> write_insert ~writing:`Dist v rest
+          | `Dist         -> write_insert ~writing:`Extra_dist v rest
+          | `Extra_dist   -> write rest);
 
-      if deflater.needed > 1
-      then begin
-        let c, l = (getter writing) (value v writing) in
-        add_bits deflater c l;
+      eval deflater
+    end else Flush
+  in
+  let write_eof deflater =
+    [%debug Logs.debug @@ fun m -> m "state: write_eof"];
 
-        deflater.k <- (match writing with
-            | `Length       -> write_insert ~writing:`Extra_length v rest
-            | `Extra_length -> write_insert ~writing:`Dist v rest
-            | `Dist         -> write_insert ~writing:`Extra_dist v rest
-            | `Extra_dist   -> write rest);
+    if deflater.needed > 1
+    then begin
+      let c, l = get_chr 256 in
 
-        eval deflater
-      end else `Flush
-    in
-    let write_eof deflater =
-      [%debug Logs.debug @@ fun m -> m "state: write_eof"];
+      add_bits deflater c l;
 
-      if deflater.needed > 1
-      then begin
-        let c, l = get_chr 256 in
+      deflater.k <- after_writing;
 
-        add_bits deflater c l;
+      eval deflater
+    end else Flush
+  in
 
-        deflater.k <- after_writing;
+  let () = match lz77 with
+    | Lz77.Buffer data :: r ->
+      deflater.i <- 0;
+      deflater.i_max <- RO.length data;
+      deflater.k <- write_buffer data r
+    | Lz77.Insert (dist, length) :: r ->
+      deflater.k <- write_insert (dist, length) r
+    | [] -> deflater.k <- write_eof
+  in
 
-        eval deflater
-      end else `Flush
-    in
+  eval deflater
 
-    let () = match lz77 with
-      | Lz77.Buffer data :: r ->
-        deflater.i <- 0;
-        deflater.i_max <- O.length data;
-        deflater.k <- write_buffer data r
-      | Lz77.Insert (dist, length) :: r ->
-        deflater.k <- write_insert (dist, length) r
-      | [] -> deflater.k <- write_eof
-    in
+and align_writing next deflater =
+  [%debug Logs.debug @@ fun m -> m "state: align_writing"];
+
+  if deflater.needed > 1
+  then begin
+    align deflater;
+    deflater.k <- next;
 
     eval deflater
+  end else Flush
 
-  and align_writing next deflater =
-    [%debug Logs.debug @@ fun m -> m "state: align_writing"];
+and write_crc1 deflater =
+  [%debug Logs.debug @@ fun m -> m "state: write_crc1"];
 
-    if deflater.needed > 1
-    then begin
-      align deflater;
-      deflater.k <- next;
+  if deflater.needed > 1
+  then begin
+    let _, a = Adler32.get deflater.crc in
 
-      eval deflater
-    end else `Flush
+    put_short_msb deflater a;
+    deflater.k <- write_crc2;
 
-  and write_crc1 deflater =
-    [%debug Logs.debug @@ fun m -> m "state: write_crc1"];
+    eval deflater
+  end else Flush
 
-    if deflater.needed > 1
-    then begin
-      let _, a = Adler32.get deflater.crc in
+and write_crc2 deflater =
+  [%debug Logs.debug @@ fun m -> m "state: write_crc2"];
 
-      put_short_msb deflater a;
-      deflater.k <- write_crc2;
+  if deflater.needed > 1
+  then begin
+    let a, _ = Adler32.get deflater.crc in
 
-      eval deflater
-    end else `Flush
+    put_short_msb deflater a;
+    deflater.k <- ok;
 
-  and write_crc2 deflater =
-    [%debug Logs.debug @@ fun m -> m "state: write_crc2"];
+    eval deflater
+  end else Flush
 
-    if deflater.needed > 1
-    then begin
-      let a, _ = Adler32.get deflater.crc in
+and error deflater = Error
 
-      put_short_msb deflater a;
-      deflater.k <- ok;
+and ok deflater = Ok
 
-      eval deflater
-    end else `Flush
+let contents { outpos; _ } =
+  outpos
 
-  and error deflater = `Error
+let flush deflater drop =
+  [%debug Logs.debug @@ fun m -> m "we flush %d byte(s)" drop];
+  deflater.needed <- deflater.needed + drop;
+  deflater.outpos <- 0;
+  [%debug Logs.debug @@ fun m -> m "we can write %d byte(s)" deflater.needed]
 
-  and ok deflater = `Ok
+let refill deflater refill =
+  [%debug Logs.debug @@ fun m -> m "we refill %d byte(s)" refill];
+  deflater.available <- deflater.available + refill;
+  deflater.inpos <- 0;
+  [%debug Logs.debug @@ fun m -> m "we can read %d byte(s)" deflater.available]
 
-  let contents { outpos; _ } =
-    outpos
+let last deflater is_last =
+  deflater.last <- is_last
 
-  let flush deflater drop =
-    [%debug Logs.debug @@ fun m -> m "we flush %d byte(s)" drop];
-    deflater.needed <- deflater.needed + drop;
-    deflater.outpos <- 0;
-    [%debug Logs.debug @@ fun m -> m "we can write %d byte(s)" deflater.needed]
+let compress ?(window_bits = 15) ?(level = 4) input output refill' flush' =
+  let deflater = make ~window_bits ~level input output in
 
-  let refill deflater refill =
-    [%debug Logs.debug @@ fun m -> m "we refill %d byte(s)" refill];
-    deflater.available <- deflater.available + refill;
-    deflater.inpos <- 0;
-    [%debug Logs.debug @@ fun m -> m "we can read %d byte(s)" deflater.available]
+  let is_last, size = refill' input in
+  last deflater is_last;
+  refill deflater size;
+  flush deflater (RW.length output);
 
-  let last deflater is_last =
-    deflater.last <- is_last
+  let rec aux () = match eval deflater with
+    | Ok ->
+      let drop = flush' output (contents deflater) in
+      flush deflater drop
+    | Flush ->
+      let drop = flush' output (contents deflater) in
+      flush deflater drop;
+      aux ()
+    | Wait ->
+      let is_last, size = refill' input in
 
-  let compress ?(window_bits = 15) ?(level = 4) input output refill' flush' =
-    let deflater = make ~window_bits ~level input output in
+      last deflater is_last;
+      refill deflater size;
+      aux ()
+    | Error -> failwith "Deflate.compress"
+  in aux ()
 
-    let is_last, size = refill' input in
-    last deflater is_last;
-    refill deflater size;
-    flush deflater (O.length output);
+let string ?window_bits ?level input output refill flush =
+  let input = RO.from_string (Bytes.unsafe_to_string input) in
+  let output = RW.from_bytes output in
 
-    let rec aux () = match eval deflater with
-      | `Ok ->
-        let drop = flush' output (contents deflater) in
-        flush deflater drop
-      | `Flush ->
-        let drop = flush' output (contents deflater) in
-        flush deflater drop;
-        aux ()
-      | `Wait ->
-        let is_last, size = refill' input in
+  let refill (v : normal RO.t) : bool * int = match v with
+    | RO.String v -> refill (Bytes.unsafe_of_string v) in
+  let flush (v : normal RW.t) : int -> int = match v with
+    | RW.Bytes v -> flush v in
 
-        last deflater is_last;
-        refill deflater size;
-        aux ()
-      | `Error -> failwith "Deflate.compress"
-    in aux ()
-end
+  compress ?window_bits ?level input output refill flush
+
+let bigstring ?window_bits ?level input output refill flush =
+  let input = RO.from_bigstring input in
+  let output = RW.from_bigstring output in
+
+  let refill (v : fast RO.t) : bool * int = match v with
+    | RO.Bigstring v -> refill v in
+  let flush (v : fast RW.t) : int -> int = match v with
+    | RW.Bigstring v -> flush v in
+
+  compress ?window_bits ?level input output refill flush

--- a/lib/decompress_deflate.mli
+++ b/lib/decompress_deflate.mli
@@ -1,65 +1,16 @@
-(** Deflate module. *)
+open Decompress_common
 
-module type S =
-sig
-  (** This type is deflater. *)
-  type t
+type ('i, 'o) t
+type 'i mode
+type state =
+  | Ok | Flush | Wait | Error
 
-  (** The type for input sources. For [`String] starts reading at the given
-      integer position. For [`Manual] the function must return the next
-      bytes and if this block is last or not and raise [End_of_file] if there
-      is no such byte. *)
-  type src
-  type dst
-  type mode
+val make     : ?window_bits:int -> ?level:int -> 'a RO.t -> 'a RW.t -> ('a, 'a) t
+val eval     : ('a, 'a) t -> state
+val contents : ('i, 'o) t -> int
+val flush    : ('i, 'o) t -> int -> unit
+val refill   : ('i, 'o) t -> int -> unit
 
-  (** Returns a new input abstraction reading from the given source. *)
-  val make : ?window_bits:int -> ?level:int -> src -> dst -> t
-
-  (** [eval deflater] performs [deflater]. The value os [eval deflater] is:
-      {ul
-      {- [`Ok] complete the document}
-      {- [`Flush] wait to flush the [dst] for re-writing a news values in
-         [dst]}
-      {- [`Error] a very bad state}
-      } *)
-  val eval : t -> [ `Ok | `Flush | `Error | `Wait ]
-
-  (** Returns a number of bytes writing in the [dst]. *)
-  val contents : t -> int
-
-  (** Clean the [dst] to re-writing a news values after. *)
-  val flush : t -> int -> unit
-
-  val refill : t -> int -> unit
-
-  val compress : ?window_bits:int -> ?level:int -> src -> dst -> (src -> bool * int) -> (dst -> int -> int) -> unit
-end
-
-module type INPUT =
-sig
-  type t
-
-  val length : t -> int
-  val get    : t -> int -> char
-end
-
-module type OUTPUT =
-sig
-  type t
-  type i
-
-  val create   : int -> t
-  val length   : t -> int
-  val blit     : t -> int -> t -> int -> int -> unit
-  val set      : t -> int -> char -> unit
-  val get      : t -> int -> char
-  val get_u16  : t -> int -> int
-  val get_u64  : t -> int -> int64
-  val sub      : t -> int -> int -> t
-  val of_input : i -> t
-end
-
-module Make (I : INPUT) (O : OUTPUT with type i = I.t) : S
-  with type src = I.t
-   and type dst = O.t
+val compress  : ?window_bits:int -> ?level:int -> 'a RO.t -> 'a RW.t -> ('a RO.t -> bool * int) -> ('a RW.t -> int -> int) -> unit
+val string    : ?window_bits:int -> ?level:int -> bytes -> bytes -> (bytes -> bool * int) -> (bytes -> int -> int) -> unit
+val bigstring : ?window_bits:int -> ?level:int -> bigstring -> bigstring -> (bigstring -> bool * int) -> (bigstring -> int -> int) -> unit

--- a/lib/decompress_huffman.ml
+++ b/lib/decompress_huffman.ml
@@ -33,8 +33,7 @@ exception Invalid_huffman
 let rec pp pp_a fmt t =
   let pp_table pp_a fmt table =
     Array.iter (fun a ->
-        Format.pp_print_tab fmt ();
-        Format.fprintf fmt "%a" pp_a a)
+        Format.fprintf fmt "\t%a" pp_a a)
       table
   in
   let pp = pp pp_a in

--- a/lib/decompress_huffman.mli
+++ b/lib/decompress_huffman.mli
@@ -5,7 +5,10 @@ val pp_code : Format.formatter -> code -> unit
 val int_of_code : code -> int
 val code_of_int : size:int -> int -> code
 
-type 'a t
+type 'a t =
+  | Node of 'a t * 'a t
+  | Flat of int * 'a t array
+  | Leaf of 'a
 
 val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
 

--- a/lib/decompress_inflate.ml
+++ b/lib/decompress_inflate.ml
@@ -1,565 +1,655 @@
 open Decompress_tables
+open Decompress_common
 
-module type INPUT =
-sig
-  type t
+let () = [%debug Logs.set_level ~all:true (Some Logs.Debug)]
+let () = [%debug Logs.set_reporter (Logs_fmt.reporter ())]
 
-  val get  : t -> int -> char
-  val sub  : t -> int -> int -> t
-  val make : int -> char -> t
-end
+exception Invalid_huffman
+exception Invalid_dictionary
+exception Invalid_header
+exception Invalid_complement_of_length
+exception Invalid_type_of_block
+exception Invalid_extrabits
+exception Invalid_distance
+exception Invalid_crc
 
-module type OUTPUT =
-sig
-  type t
-  type i
+module Adler32 = Decompress_adler32
+module Window  = Decompress_window
+module Huffman = Decompress_huffman
 
-  val create : int -> t
-  val length : t -> int
-  val blit   : t -> int -> t -> int -> int -> unit
-  val iblit  : i -> int -> t -> int -> int -> unit
-  val get    : t -> int -> char
-  val set    : t -> int -> char -> unit
-end
+type ('i, 'o) t =
+  { src                   : 'i RO.t
+  ; dst                   : 'o RW.t
+  ; mutable last          : bool
+    (** true if processing last block *)
+  ; mutable hold          : int
+    (** input bit accumulator *)
+  ; mutable bits          : int
+    (** number of bits in "hold" *)
+  ; mutable outpos        : int
+    (** position output buffer *)
+  ; mutable needed        : int
+  ; mutable inpos         : int
+    (** position input buffer *)
+  ; mutable available     : int
+  ; mutable k             : ('i, 'o) t -> state }
+and state =
+  | Ok | Flush | Wait | Error
 
-module type S =
-sig
-  type t
-  type src
-  type dst
+exception Expected_data
 
-  val make : src -> dst -> t
-  val eval : t -> [`Ok | `Flush | `Error | `Wait ]
+let eval inflater =
+  inflater.k inflater
 
-  val flush    : int -> int -> t -> unit
-  val refill   : int -> int -> t -> unit
-  val used_in  : t -> int
-  val used_out : t -> int
+let get_bytes n blit k inflater =
+  let rec loop rest inflater =
+    let can = min (inflater.available - inflater.inpos) rest in
 
-  val decompress : src -> dst -> (src -> int) -> (dst -> int -> int) -> unit
-end
+    [%debug Logs.debug @@ fun m -> m "state: get_bytes [can: %d, rest: %d]" can rest];
 
-module Make (I : INPUT) (O : OUTPUT with type i = I.t) : S
-  with type src = I.t
-   and type dst = O.t =
-struct
-  let () = [%debug Logs.set_level ~all:true (Some Logs.Debug)]
-  let () = [%debug Logs.set_reporter (Logs_fmt.reporter ())]
+    match can, rest with
+    | 0, r when r > 0 -> (inflater.k <- loop rest; Wait)
+    | n, r when r > 0 ->
+      blit inflater.src inflater.inpos can
+        (fun inflater ->
+         [%debug Logs.debug @@ fun m -> m "state: get_bytes [blit]"];
 
-  exception Invalid_huffman
-  exception Invalid_dictionary
-  exception Invalid_header
-  exception Invalid_complement_of_length
-  exception Invalid_type_of_block
-  exception Invalid_extrabits
-  exception Invalid_distance
-  exception Invalid_crc
+         inflater.inpos <- inflater.inpos + can;
+         loop (rest - can) inflater)
+        inflater
+    | _ -> k inflater
+  in
 
-  module O = struct type elt = char [@@immmediate] include O end
-  module Adler32 = Decompress_adler32.Make(Char)(O)
-  module Window  = Decompress_window.Make(Char)(O)
-  module Huffman = Decompress_huffman
+  loop n inflater
 
-  type dst = O.t
-  type src = I.t
+let rec get_byte' k inflater =
+  if inflater.available - inflater.inpos > 0
+  then begin
+    let code = Char.code @@ RO.get inflater.src inflater.inpos in
+    inflater.inpos <- inflater.inpos + 1;
 
-  type t =
-    { src                   : src
-    ; dst                   : dst
-    ; mutable last          : bool
-      (** true if processing last block *)
-    ; mutable hold          : int
-      (** input bit accumulator *)
-    ; mutable bits          : int
-      (** number of bits in "hold" *)
-    ; mutable outpos        : int
-      (** position output buffer *)
-    ; mutable needed        : int
-    ; mutable inpos         : int
-      (** position input buffer *)
-    ; mutable available     : int
-    ; mutable k             : t -> [ `Ok | `Flush | `Wait | `Error ] }
+    k code inflater
+  end else begin
+    inflater.k <- get_byte' k;
 
-  exception Expected_data
+    Wait
+  end
 
-  let eval inflater =
-    inflater.k inflater
+let reset_bits inflater =
+  inflater.hold <- 0;
+  inflater.bits <- 0
 
-  let get_bytes n blit k inflater =
-    let rec loop rest inflater =
-      let can = min (inflater.available - inflater.inpos) rest in
+let get_bit k inflater =
+  let rec aux infalter =
+    let result = inflater.hold land 1 = 1 in
+    inflater.bits <- inflater.bits - 1;
+    inflater.hold <- inflater.hold lsr 1;
 
-      [%debug Logs.debug @@ fun m -> m "state: get_bytes [can: %d, rest: %d]" can rest];
+    k result inflater
+  in
 
-      match can, rest with
-      | 0, r when r > 0 -> (inflater.k <- loop rest; `Wait)
-      | n, r when r > 0 ->
-        blit inflater.src inflater.inpos can
-          (fun inflater ->
-           [%debug Logs.debug @@ fun m -> m "state: get_bytes [blit]"];
+  if inflater.bits = 0
+  then get_byte' (fun byte inflater ->
+                  inflater.hold <- byte;
+                  inflater.bits <- 8;
 
-           inflater.inpos <- inflater.inpos + can;
-           loop (rest - can) inflater)
-          inflater
-      | _ -> k inflater
-    in
+                  aux inflater)
+         inflater
+  else aux inflater
 
-    loop n inflater
+let rec huffman_read_and_find_get_bit_get_bits tree k state = match tree with
+  | Huffman.Leaf i -> k i state
+  | Huffman.Node (a, b) ->
+    get_bit_specialized k a b state
+  | Huffman.Flat (n, a) ->
+    get_bits_specialized k a n state
+and get_bit_specialized kk a b inflater =
+  if inflater.bits = 0
+  then get_byte'_specialized a b kk inflater
+  else get_bit_specialized_aux a b kk inflater
+and get_bit_specialized_aux a b kk inflater =
+  let result = inflater.hold land 1 = 1 in
+  inflater.bits <- inflater.bits - 1;
+  inflater.hold <- inflater.hold lsr 1;
+  if result
+  then huffman_read_and_find_get_bit_get_bits b kk inflater
+  else huffman_read_and_find_get_bit_get_bits a kk inflater
+and get_byte'_specialized a b kk  inflater =
+  if inflater.available - inflater.inpos > 0
+  then begin
+    let code = Char.code @@ RO.get inflater.src inflater.inpos in
+    inflater.inpos <- inflater.inpos + 1;
+    inflater.hold <- code;
+    inflater.bits <- 8;
+    get_bit_specialized_aux a b kk inflater
+  end else begin
+    inflater.k <- get_byte'_specialized a b kk;
+    Wait
+  end
+and get_bits_specialized kk a n inflater =
+  if inflater.bits < n
+  then get_byte'_loop kk a n inflater
+  else
+    let result = inflater.hold land (1 lsl n - 1) in
+    inflater.bits <- inflater.bits - n;
+    inflater.hold <- inflater.hold lsr n;
+    huffman_read_and_find_get_bit_get_bits (Array.get a result) kk inflater
+and get_byte'_loop kk a n inflater =
+  if inflater.available - inflater.inpos > 0
+  then begin
+    let code = Char.code @@ RO.get inflater.src inflater.inpos in
+    inflater.inpos <- inflater.inpos + 1;
+    inflater.hold <- inflater.hold lor (code lsl inflater.bits);
+    inflater.bits <- inflater.bits + 8;
+    get_bits_specialized kk a n inflater
+  end else begin
+    inflater.k <- (get_byte'_loop kk a n);
+    Wait
+  end
 
-  let rec get_byte' k inflater =
-    if inflater.available - inflater.inpos > 0
-    then begin
-      let code = Char.code @@ I.get inflater.src inflater.inpos in
-      inflater.inpos <- inflater.inpos + 1;
+let reverse_bits =
+  let t =
+    [| 0x00; 0x80; 0x40; 0xC0; 0x20; 0xA0; 0x60; 0xE0; 0x10; 0x90; 0x50; 0xD0;
+       0x30; 0xB0; 0x70; 0xF0; 0x08; 0x88; 0x48; 0xC8; 0x28; 0xA8; 0x68; 0xE8;
+       0x18; 0x98; 0x58; 0xD8; 0x38; 0xB8; 0x78; 0xF8; 0x04; 0x84; 0x44; 0xC4;
+       0x24; 0xA4; 0x64; 0xE4; 0x14; 0x94; 0x54; 0xD4; 0x34; 0xB4; 0x74; 0xF4;
+       0x0C; 0x8C; 0x4C; 0xCC; 0x2C; 0xAC; 0x6C; 0xEC; 0x1C; 0x9C; 0x5C; 0xDC;
+       0x3C; 0xBC; 0x7C; 0xFC; 0x02; 0x82; 0x42; 0xC2; 0x22; 0xA2; 0x62; 0xE2;
+       0x12; 0x92; 0x52; 0xD2; 0x32; 0xB2; 0x72; 0xF2; 0x0A; 0x8A; 0x4A; 0xCA;
+       0x2A; 0xAA; 0x6A; 0xEA; 0x1A; 0x9A; 0x5A; 0xDA; 0x3A; 0xBA; 0x7A; 0xFA;
+       0x06; 0x86; 0x46; 0xC6; 0x26; 0xA6; 0x66; 0xE6; 0x16; 0x96; 0x56; 0xD6;
+       0x36; 0xB6; 0x76; 0xF6; 0x0E; 0x8E; 0x4E; 0xCE; 0x2E; 0xAE; 0x6E; 0xEE;
+       0x1E; 0x9E; 0x5E; 0xDE; 0x3E; 0xBE; 0x7E; 0xFE; 0x01; 0x81; 0x41; 0xC1;
+       0x21; 0xA1; 0x61; 0xE1; 0x11; 0x91; 0x51; 0xD1; 0x31; 0xB1; 0x71; 0xF1;
+       0x09; 0x89; 0x49; 0xC9; 0x29; 0xA9; 0x69; 0xE9; 0x19; 0x99; 0x59; 0xD9;
+       0x39; 0xB9; 0x79; 0xF9; 0x05; 0x85; 0x45; 0xC5; 0x25; 0xA5; 0x65; 0xE5;
+       0x15; 0x95; 0x55; 0xD5; 0x35; 0xB5; 0x75; 0xF5; 0x0D; 0x8D; 0x4D; 0xCD;
+       0x2D; 0xAD; 0x6D; 0xED; 0x1D; 0x9D; 0x5D; 0xDD; 0x3D; 0xBD; 0x7D; 0xFD;
+       0x03; 0x83; 0x43; 0xC3; 0x23; 0xA3; 0x63; 0xE3; 0x13; 0x93; 0x53; 0xD3;
+       0x33; 0xB3; 0x73; 0xF3; 0x0B; 0x8B; 0x4B; 0xCB; 0x2B; 0xAB; 0x6B; 0xEB;
+       0x1B; 0x9B; 0x5B; 0xDB; 0x3B; 0xBB; 0x7B; 0xFB; 0x07; 0x87; 0x47; 0xC7;
+       0x27; 0xA7; 0x67; 0xE7; 0x17; 0x97; 0x57; 0xD7; 0x37; 0xB7; 0x77; 0xF7;
+       0x0F; 0x8F; 0x4F; 0xCF; 0x2F; 0xAF; 0x6F; 0xEF; 0x1F; 0x9F; 0x5F; 0xDF;
+       0x3F; 0xBF; 0x7F; 0xFF |]
+  in
+  fun bits -> t.(bits)
 
-      k code inflater
-    end else begin
-      inflater.k <- get_byte' k;
+let get_bits n k inflater =
+  let aux inflater =
+    let result = inflater.hold land (1 lsl n - 1) in
+    inflater.bits <- inflater.bits - n;
+    inflater.hold <- inflater.hold lsr n;
 
-      `Wait
-    end
+    k result inflater
+  in
 
-  let reset_bits inflater =
-    inflater.hold <- 0;
-    inflater.bits <- 0
-
-  let get_bit k inflater =
-    let rec aux infalter =
-      let result = inflater.hold land 1 = 1 in
-      inflater.bits <- inflater.bits - 1;
-      inflater.hold <- inflater.hold lsr 1;
-
-      k result inflater
-    in
-
-    if inflater.bits = 0
+  let rec loop inflater =
+    if inflater.bits < n
     then get_byte' (fun byte inflater ->
-                    inflater.hold <- byte;
-                    inflater.bits <- 8;
+                    inflater.hold <- inflater.hold lor (byte lsl inflater.bits);
+                    inflater.bits <- inflater.bits + 8;
 
-                    aux inflater)
-           inflater
+                    loop inflater) inflater
     else aux inflater
+  in
 
-  let reverse_bits =
-    let t =
-      [| 0x00; 0x80; 0x40; 0xC0; 0x20; 0xA0; 0x60; 0xE0; 0x10; 0x90; 0x50; 0xD0;
-         0x30; 0xB0; 0x70; 0xF0; 0x08; 0x88; 0x48; 0xC8; 0x28; 0xA8; 0x68; 0xE8;
-         0x18; 0x98; 0x58; 0xD8; 0x38; 0xB8; 0x78; 0xF8; 0x04; 0x84; 0x44; 0xC4;
-         0x24; 0xA4; 0x64; 0xE4; 0x14; 0x94; 0x54; 0xD4; 0x34; 0xB4; 0x74; 0xF4;
-         0x0C; 0x8C; 0x4C; 0xCC; 0x2C; 0xAC; 0x6C; 0xEC; 0x1C; 0x9C; 0x5C; 0xDC;
-         0x3C; 0xBC; 0x7C; 0xFC; 0x02; 0x82; 0x42; 0xC2; 0x22; 0xA2; 0x62; 0xE2;
-         0x12; 0x92; 0x52; 0xD2; 0x32; 0xB2; 0x72; 0xF2; 0x0A; 0x8A; 0x4A; 0xCA;
-         0x2A; 0xAA; 0x6A; 0xEA; 0x1A; 0x9A; 0x5A; 0xDA; 0x3A; 0xBA; 0x7A; 0xFA;
-         0x06; 0x86; 0x46; 0xC6; 0x26; 0xA6; 0x66; 0xE6; 0x16; 0x96; 0x56; 0xD6;
-         0x36; 0xB6; 0x76; 0xF6; 0x0E; 0x8E; 0x4E; 0xCE; 0x2E; 0xAE; 0x6E; 0xEE;
-         0x1E; 0x9E; 0x5E; 0xDE; 0x3E; 0xBE; 0x7E; 0xFE; 0x01; 0x81; 0x41; 0xC1;
-         0x21; 0xA1; 0x61; 0xE1; 0x11; 0x91; 0x51; 0xD1; 0x31; 0xB1; 0x71; 0xF1;
-         0x09; 0x89; 0x49; 0xC9; 0x29; 0xA9; 0x69; 0xE9; 0x19; 0x99; 0x59; 0xD9;
-         0x39; 0xB9; 0x79; 0xF9; 0x05; 0x85; 0x45; 0xC5; 0x25; 0xA5; 0x65; 0xE5;
-         0x15; 0x95; 0x55; 0xD5; 0x35; 0xB5; 0x75; 0xF5; 0x0D; 0x8D; 0x4D; 0xCD;
-         0x2D; 0xAD; 0x6D; 0xED; 0x1D; 0x9D; 0x5D; 0xDD; 0x3D; 0xBD; 0x7D; 0xFD;
-         0x03; 0x83; 0x43; 0xC3; 0x23; 0xA3; 0x63; 0xE3; 0x13; 0x93; 0x53; 0xD3;
-         0x33; 0xB3; 0x73; 0xF3; 0x0B; 0x8B; 0x4B; 0xCB; 0x2B; 0xAB; 0x6B; 0xEB;
-         0x1B; 0x9B; 0x5B; 0xDB; 0x3B; 0xBB; 0x7B; 0xFB; 0x07; 0x87; 0x47; 0xC7;
-         0x27; 0xA7; 0x67; 0xE7; 0x17; 0x97; 0x57; 0xD7; 0x37; 0xB7; 0x77; 0xF7;
-         0x0F; 0x8F; 0x4F; 0xCF; 0x2F; 0xAF; 0x6F; 0xEF; 0x1F; 0x9F; 0x5F; 0xDF;
-         0x3F; 0xBF; 0x7F; 0xFF |]
-    in
-    fun bits -> t.(bits)
+  loop inflater
 
-  let get_bits n k inflater =
-    let aux inflater =
-      let result = inflater.hold land (1 lsl n - 1) in
-      inflater.bits <- inflater.bits - n;
-      inflater.hold <- inflater.hold lsr n;
+let get_ui16 k inflater =
+  get_byte' (fun a -> get_byte' (fun b -> k (a lor (b lsl 8)))) inflater
 
-      k result inflater
+let get_revbits n k inflater =
+  (* XXX: this function accepts only [n <= 8] *)
+  get_bits n (fun o -> k @@ reverse_bits (o lsl (8 - n))) inflater
+
+module Dictionary =
+struct
+  type t =
+    { mutable iterator : int
+    ; mutable previous : int
+    ; max              : int
+    ; dictionary       : int array }
+
+  let make max =
+    { iterator = 0
+    ; previous = 0
+    ; max
+    ; dictionary = Array.make max 0 }
+
+  let inflate (tree, max) k inflater =
+    let get next inflater =
+      huffman_read_and_find_get_bit_get_bits
+        tree next inflater
     in
 
-    let rec loop inflater =
-      if inflater.bits < n
-      then get_byte' (fun byte inflater ->
-                      inflater.hold <- inflater.hold lor (byte lsl inflater.bits);
-                      inflater.bits <- inflater.bits + 8;
+    let state = make max in
 
-                      loop inflater) inflater
-      else aux inflater
-    in
+    let rec loop result inflater = match result with
+      | n when n <= 15 ->
+        [%debug Logs.debug @@ fun m -> m "state: inflate_dict [%d]" n];
+        state.previous <- n;
+        Array.set state.dictionary state.iterator n;
+        state.iterator <- state.iterator + 1;
 
-    loop inflater
+        if state.iterator < state.max
+        then get loop inflater
+        else k state.dictionary inflater
+      | 16 ->
+        [%debug Logs.debug @@ fun m -> m "state: inflate_dict [%d]" 16];
+        let aux n inflater =
+          if state.iterator + n + 3 > state.max
+          then raise Invalid_dictionary;
 
-  let get_ui16 k inflater =
-    get_byte' (fun a -> get_byte' (fun b -> k (a lor (b lsl 8)))) inflater
-
-  let get_revbits n k inflater =
-    (* XXX: this function accepts only [n <= 8] *)
-    get_bits n (fun o -> k @@ reverse_bits (o lsl (8 - n))) inflater
-
-  module Dictionary =
-  struct
-    type t =
-      { mutable iterator : int
-      ; mutable previous : int
-      ; max              : int
-      ; dictionary       : int array }
-
-    let make max =
-      { iterator = 0
-      ; previous = 0
-      ; max
-      ; dictionary = Array.make max 0 }
-
-    let inflate (tree, max) k inflater =
-      let get next inflater =
-        Huffman.read_and_find
-          get_bit get_bits tree next inflater
-      in
-
-      let state = make max in
-
-      let rec loop result inflater = match result with
-        | n when n <= 15 ->
-          [%debug Logs.debug @@ fun m -> m "state: inflate_dict [%d]" n];
-          state.previous <- n;
-          Array.set state.dictionary state.iterator n;
-          state.iterator <- state.iterator + 1;
+          for j = 0 to n + 3 - 1 do
+            Array.set state.dictionary state.iterator state.previous;
+            state.iterator <- state.iterator + 1;
+          done;
 
           if state.iterator < state.max
           then get loop inflater
           else k state.dictionary inflater
-        | 16 ->
-          [%debug Logs.debug @@ fun m -> m "state: inflate_dict [%d]" 16];
-          let aux n inflater =
-            if state.iterator + n + 3 > state.max
-            then raise Invalid_dictionary;
-
-            for j = 0 to n + 3 - 1 do
-              Array.set state.dictionary state.iterator state.previous;
-              state.iterator <- state.iterator + 1;
-            done;
-
-            if state.iterator < state.max
-            then get loop inflater
-            else k state.dictionary inflater
-          in
-
-          get_bits 2 aux inflater
-        | 17 ->
-          [%debug Logs.debug @@ fun m -> m "state: inflate_dict [%d]" 17];
-          let aux n inflater =
-            if state.iterator + n + 3 > state.max
-            then raise Invalid_dictionary;
-
-            state.iterator <- state.iterator + n + 3;
-
-            if state.iterator < state.max
-            then get loop inflater
-            else k state.dictionary inflater
-          in
-
-          get_bits 3 aux inflater
-        | 18 ->
-          [%debug Logs.debug @@ fun m -> m "state: inflate_dict [%d]" 18];
-          let aux n inflater =
-            if state.iterator + n + 11 > state.max
-            then raise Invalid_dictionary;
-
-            state.iterator <- state.iterator + n + 11;
-
-            if state.iterator < state.max
-            then get loop inflater
-            else k state.dictionary inflater
-          in
-
-          get_bits 7 aux inflater
-        | _ -> raise Invalid_dictionary
-      in
-
-      get loop inflater
-  end
-
-  let fixed_huffman =
-    Array.init 288
-      (fun n ->
-         if n < 144 then 8
-         else if n < 256 then 9
-         else if n < 280 then 7
-         else 8)
-    |> fun lengths -> Huffman.make lengths 0 288 9
-
-  let rec put_chr window chr next inflater =
-    [%debug Logs.debug @@ fun m -> m "state: put_chr [%S]" (String.make 1 chr)];
-
-    if inflater.outpos < inflater.needed
-    then begin
-      O.set inflater.dst inflater.outpos chr;
-      Window.add_atom chr window;
-      inflater.outpos <- inflater.outpos + 1;
-
-      next inflater
-    end else (inflater.k <- put_chr window chr next; `Flush)
-
-  let rec put_bytes window bytes off len next inflater =
-    [%debug Logs.debug @@ fun m -> m "state: put_bytes [%S]" (I.sub bytes off len |> Obj.magic)];
-
-    if inflater.outpos < inflater.needed
-    then begin
-      let n = min (inflater.needed - inflater.outpos) len in
-      O.iblit bytes off inflater.dst inflater.outpos n;
-      Window.add_buffer inflater.dst inflater.outpos n window;
-      inflater.outpos <- inflater.outpos + n;
-
-      if len - n > 0
-      then put_bytes window bytes (off + n) (len - n) next inflater
-      else next inflater
-    end else (inflater.k <- put_bytes window bytes off len next; `Flush)
-
-  let rec ok inflater = `Ok
-
-  and switch window inflater =
-    if inflater.last = true
-    then crc window inflater
-    else last window inflater
-
-  and crc window inflater =
-    let check b a inflater =
-      [%debug Logs.debug @@ fun m -> m "state: crc [%d:%d]" a b];
-
-      if Adler32.neq (Adler32.make a b) (Window.checksum window)
-      then raise Invalid_crc;
-
-      ok inflater
-    in
-
-    let read_a2b a1a a1b a2a a2b = check ((a1a lsl 8) lor a1b) ((a2a lsl 8) lor a2b) in
-    let read_a2a a1a a1b a2a     = get_byte' (read_a2b a1a a1b a2a) in
-    let read_a1b a1a a1b         = get_byte' (read_a2a a1a a1b) in
-    let read_a1a a1a             = get_byte' (read_a1b a1a) in
-
-    get_byte' read_a1a inflater
-
-  and flat window inflater =
-    let rec loop len inflater =
-      let available_to_read = min (inflater.available - inflater.inpos) len in
-      let available_to_write = min (inflater.needed - inflater.outpos) available_to_read in
-
-      if len = 0 then switch window inflater
-      else match available_to_read, available_to_write with
-           | 0, n ->
-             inflater.k <- loop len;
-             `Wait
-           | n, 0 ->
-             inflater.k <- loop len;
-             `Flush
-           | _, n ->
-             get_bytes n
-               (put_bytes window)
-               (loop (len - n))
-               inflater
-    in
-    let header len nlen inflater =
-      if nlen <> 0xFFFF - len
-      then raise Invalid_complement_of_length
-      else begin
-        reset_bits inflater;
-        loop len inflater
-      end
-
-    in
-
-    get_ui16 (fun len -> get_ui16 (fun nlen -> header len nlen)) inflater
-
-  and inflate window get_chr get_dst inflater =
-    [%debug Logs.debug @@ fun m -> m "state: inflate"];
-
-    let rec loop length inflater =
-      [%debug Logs.debug @@ fun m -> m "state: inflate [%d]" length];
-
-      match length with
-      | n when n < 256 ->
-        put_chr window (Char.chr n) (get_chr loop) inflater
-      | 256 ->
-        switch window inflater
-      | n ->
-        let write length dist inflater =
-          [%debug Logs.debug @@ fun m -> m "state: write [%d:%d]" length dist];
-
-          match dist with
-          | 1 ->
-            (* XXX: allocation! *)
-            let tmp = I.make length (Window.last window) in
-            put_bytes window tmp 0 length (get_chr loop) inflater
-          | n ->
-            (* TODO: optimize! use [put_bytes] *)
-            let rec loop' rem inflater =
-              [%debug Logs.debug @@ fun m -> m "state: dist [%d]" rem];
-
-              if rem = 0
-              then get_chr loop inflater
-              else put_chr window (Window.get window dist) (loop' (rem - 1)) inflater
-            in
-
-            loop' length inflater
         in
 
-        let read_extra_dist length dist inflater =
-          let n = Array.get _extra_dbits dist in
-          get_bits n (fun extra -> write length @@ (Array.get _base_dist dist) + 1 + extra) inflater
+        get_bits 2 aux inflater
+      | 17 ->
+        [%debug Logs.debug @@ fun m -> m "state: inflate_dict [%d]" 17];
+        let aux n inflater =
+          if state.iterator + n + 3 > state.max
+          then raise Invalid_dictionary;
+
+          state.iterator <- state.iterator + n + 3;
+
+          if state.iterator < state.max
+          then get loop inflater
+          else k state.dictionary inflater
         in
 
-        let read_extra_length length inflater =
-          let n = Array.get _extra_lbits length in
-          get_bits n (fun extra -> get_dst @@ read_extra_dist ((Array.get _base_length length) + 3 + extra)) inflater
+        get_bits 3 aux inflater
+      | 18 ->
+        [%debug Logs.debug @@ fun m -> m "state: inflate_dict [%d]" 18];
+        let aux n inflater =
+          if state.iterator + n + 11 > state.max
+          then raise Invalid_dictionary;
+
+          state.iterator <- state.iterator + n + 11;
+
+          if state.iterator < state.max
+          then get loop inflater
+          else k state.dictionary inflater
         in
 
-        read_extra_length (n - 257) inflater
+        get_bits 7 aux inflater
+      | _ -> raise Invalid_dictionary
     in
 
-    get_chr loop inflater
-
-  and fixed window inflater =
-    let get_chr next inflater =
-      Huffman.read_and_find
-        get_bit get_bits fixed_huffman next inflater
-    in
-
-    let get_dst next =
-      get_revbits 5 next
-    in
-
-    inflate window get_chr get_dst inflater
-
-  and dynamic window inflater =
-    [%debug Logs.debug @@ fun m -> m "state: dynamic"];
-
-    let print_arr ~sep print_data fmt arr =
-      let rec aux = function
-        | [] -> ()
-        | [ x ] -> print_data fmt x
-        | x :: r -> Format.fprintf fmt "%a%s" print_data x sep; aux r
-      in
-
-      aux (Array.to_list arr)
-    in
-    let print_int = Format.pp_print_int in
-
-    let make_table hlit hdist hclen buf inflater =
-      [%debug Logs.debug @@ fun m -> m "state: make_table [%d:%d:%d]" hlit hdist hclen];
-      [%debug Logs.debug @@ fun m -> m "state: make_table [%a]" (print_arr ~sep:"; " print_int) buf];
-
-      Dictionary.inflate
-        (Huffman.make buf 0 19 7, hlit + hdist)
-        (fun dict inflater ->
-         let huffman_chr = Huffman.make dict 0 hlit 15 in
-         let huffman_dst = Huffman.make dict hlit hdist 15 in
-
-         let get_chr next inflater =
-           Huffman.read_and_find get_bit get_bits huffman_chr next inflater
-         in
-
-         let get_dst next inflater =
-           Huffman.read_and_find get_bit get_bits huffman_dst next inflater
-         in
-
-         inflate window get_chr get_dst inflater)
-        inflater
-    in
-    let read_table hlit hdist hclen inflater =
-      let buf = Array.make 19 0 in
-
-      let rec loop iterator code inflater =
-        Array.set buf (Array.get hclen_order iterator) code;
-
-        if iterator + 1 = hclen
-        then begin
-          for i = hclen to 18 do Array.set buf (Array.get hclen_order i) 0 done;
-          make_table hlit hdist hclen buf inflater
-        end else get_bits 3 (loop (iterator + 1)) inflater
-      in
-
-      get_bits 3 (loop 0) inflater
-    in
-    let read_hclen hlit hdist = get_bits 4 (fun hclen -> read_table hlit hdist @@ hclen + 4) in
-    let read_hdist hlit       = get_bits 5 (fun hdist -> read_hclen hlit @@ hdist + 1) in
-    let read_hlit             = get_bits 5 (fun hlit  -> read_hdist @@ hlit + 257) in
-
-    read_hlit inflater
-
-  and block window inflater =
-    get_bits 2
-      (fun n inflater ->
-       [%debug Logs.debug @@ fun m -> m "state: block [%d]" n];
-
-       match n with
-       | 0 -> flat window inflater
-       | 1 -> fixed window inflater
-       | 2 -> dynamic window inflater
-       | _ -> raise Invalid_type_of_block)
-      inflater
-
-  and last window inflater =
-    get_bit (fun last inflater ->
-             [%debug Logs.debug @@ fun m -> m "state: last [%b]" last];
-
-             inflater.last <- last;
-             block window inflater)
-       inflater
-
-  and header inflater =
-    let aux byte0 byte1 inflater =
-      [%debug Logs.debug @@ fun m -> m "state: header [%d:%d]" byte0 byte1];
-
-      let window = Window.init ~bits:(byte0 lsr 4 + 8) () in
-      last window inflater
-    in
-
-    get_byte' (fun byte0 -> get_byte' (fun byte1 -> aux byte0 byte1)) inflater
-
-  let make src dst =
-    { src
-    ; dst
-
-    ; last      = false
-    ; hold      = 0
-    ; bits      = 0
-
-    ; outpos    = 0
-    ; needed    = 0
-
-    ; inpos     = 0
-    ; available = 0
-
-    ; k         = header }
-
-  let refill off len inflater =
-    inflater.inpos <- off;
-    inflater.available <- off + len
-
-  let flush off len inflater =
-    inflater.outpos <- off;
-    inflater.needed <- off + len
-
-  let used_in  { inpos; _ } = inpos
-  let used_out { outpos; _ } = outpos
-
-  let decompress src dst refill' flush' =
-    let inflater = make src dst in
-
-    flush 0 (O.length dst) inflater;
-
-    let rec aux () = match eval inflater with
-      | `Ok ->
-        let drop = flush' dst (used_out inflater) in
-        flush 0 drop inflater
-      | `Flush ->
-        let drop = flush' dst (used_out inflater) in
-        flush 0 drop inflater; aux ()
-      | `Wait ->
-        let fill = refill' src in
-        refill 0 fill inflater; aux ()
-      | `Error -> failwith "Inflate.decompress"
-    in
-
-    aux ()
+    get loop inflater
 end
+
+let fixed_huffman =
+  Array.init 288
+    (fun n ->
+       if n < 144 then 8
+       else if n < 256 then 9
+       else if n < 280 then 7
+       else 8)
+  |> fun lengths -> Huffman.make lengths 0 288 9
+
+let rec put_chr window chr next inflater =
+  [%debug Logs.debug @@ fun m -> m "state: put_chr [%S]" (String.make 1 chr)];
+
+  if inflater.outpos < inflater.needed
+  then begin
+    RW.set inflater.dst inflater.outpos chr;
+    Window.add_char chr window;
+    inflater.outpos <- inflater.outpos + 1;
+
+    next inflater
+  end else (inflater.k <- put_chr window chr next; Flush)
+
+let rec put_bytes window buff off len next inflater =
+  let safe_window_add_ro window buff off len =
+    let size = RO.length buff in
+
+    let pre = size - off in
+    let extra = len - pre in
+
+    if extra > 0 then begin
+      [%debug Logs.debug @@ fun m -> m "safe_window_add_ro> %a and %a"
+       RO.pp (RO.sub buff off pre)
+       RO.pp (RO.sub buff 0 extra)];
+
+      Window.add_ro buff off pre window;
+      Window.add_ro buff 0 extra window;
+    end else begin
+      [%debug Logs.debug @@ fun m -> m "window_add_ro> %a"
+       RO.pp (RO.sub buff off len)];
+
+      Window.add_ro buff off len window
+    end
+  in
+  let safe_blit_ro src src_off dst dst_off len =
+    let size = RO.length src in
+
+    let pre = size - src_off in
+    let extra = len - pre in
+
+    if extra > 0 then begin
+      [%debug Logs.debug @@ fun m -> m "safe_blit_ro> %a and %a"
+       RO.pp (RO.sub buff off pre)
+       RO.pp (RO.sub buff 0 extra)];
+
+      RW_ext.blit_ro src src_off dst dst_off pre;
+      RW_ext.blit_ro src 0 dst (dst_off + pre) extra;
+    end else begin
+      [%debug Logs.debug @@ fun m -> m "blit_ro> %a"
+       RO.pp (RO.sub buff off len)];
+
+      RW_ext.blit_ro src src_off dst dst_off len
+    end
+  in
+
+  if inflater.outpos < inflater.needed
+  then begin
+    let n = min (inflater.needed - inflater.outpos) len in
+    [%debug Logs.debug @@ fun m -> m "state: put_bytes window"];
+    safe_window_add_ro window buff off n;
+    [%debug Logs.debug @@ fun m -> m "state: put_bytes blit"];
+    safe_blit_ro buff off inflater.dst inflater.outpos n;
+    inflater.outpos <- inflater.outpos + n;
+
+    if len - n > 0
+    then put_bytes window buff (off + n) (len - n) next inflater
+    else next inflater
+  end else (inflater.k <- put_bytes window buff off len next; Flush)
+
+let rec fill_byte window chr len next inflater =
+  if inflater.outpos < inflater.needed
+  then begin
+    let n = min (inflater.needed - inflater.outpos) len in
+    Window.fill chr n window;
+    RW.fill inflater.dst inflater.outpos n chr;
+    inflater.outpos <- inflater.outpos + n;
+
+    if len - n > 0
+    then fill_byte window chr (len - n) next inflater
+    else next inflater
+  end else (inflater.k <- fill_byte window chr len next; Flush)
+
+let rec ok inflater = Ok
+
+and switch window inflater =
+  if inflater.last = true
+  then crc window inflater
+  else last window inflater
+
+and crc window inflater =
+  let check b a inflater =
+    [%debug Logs.debug @@ fun m -> m "state: crc [%d:%d]" a b];
+
+    (*
+    if Adler32.neq (Adler32.make a b) (Window.checksum window)
+    then raise Invalid_crc; *)
+
+    ok inflater
+  in
+
+  let read_a2b a1a a1b a2a a2b = check ((a1a lsl 8) lor a1b) ((a2a lsl 8) lor a2b) in
+  let read_a2a a1a a1b a2a     = get_byte' (read_a2b a1a a1b a2a) in
+  let read_a1b a1a a1b         = get_byte' (read_a2a a1a a1b) in
+  let read_a1a a1a             = get_byte' (read_a1b a1a) in
+
+  get_byte' read_a1a inflater
+
+and flat window inflater =
+  let rec loop len inflater =
+    let available_to_read = min (inflater.available - inflater.inpos) len in
+    let available_to_write = min (inflater.needed - inflater.outpos) available_to_read in
+
+    if len = 0 then switch window inflater
+    else match available_to_read, available_to_write with
+         | 0, n ->
+           inflater.k <- loop len;
+           Wait
+         | n, 0 ->
+           inflater.k <- loop len;
+           Flush
+         | _, n ->
+           get_bytes n
+             (put_bytes window)
+             (loop (len - n))
+             inflater
+  in
+  let header len nlen inflater =
+    if nlen <> 0xFFFF - len
+    then raise Invalid_complement_of_length
+    else begin
+      reset_bits inflater;
+      loop len inflater
+    end
+
+  in
+
+  get_ui16 (fun len -> get_ui16 (fun nlen -> header len nlen)) inflater
+
+and inflate window get_chr get_dst inflater =
+  [%debug Logs.debug @@ fun m -> m "state: inflate"];
+
+  let rec loop length inflater =
+    [%debug Logs.debug @@ fun m -> m "state: inflate [%d]" length];
+
+    match length with
+    | n when n < 256 ->
+      put_chr window (Char.chr n) (get_chr loop) inflater
+    | 256 ->
+      switch window inflater
+    | n ->
+      let write length dist inflater =
+        [%debug Logs.debug @@ fun m -> m "state: write [%d:%d]" length dist];
+
+        match dist with
+        | 1 ->
+          let open Window in
+          let open RingBuffer in
+
+          let chr = RW.get window.window.buffer (window.window % (window.window.wpos - 1)) in
+
+          [%debug Logs.debug @@ fun m -> m "we will fill the char [%S]" (String.make length chr)];
+          fill_byte window chr length (get_chr loop) inflater;
+        | n ->
+          let open Window in
+          let open RingBuffer in
+
+          [%debug Logs.debug @@ fun m -> m "we will put a bytes"];
+
+          put_bytes window (to_ro window.window.buffer)
+            (window.window % (window.window.wpos - dist))
+            length
+            (get_chr loop)
+            inflater
+      in
+
+      let read_extra_dist length dist inflater =
+        let n = Array.get _extra_dbits dist in
+        get_bits n (fun extra -> write length @@ (Array.get _base_dist dist) + 1 + extra) inflater
+      in
+
+      let read_extra_length length inflater =
+        let n = Array.get _extra_lbits length in
+        get_bits n (fun extra -> get_dst @@ read_extra_dist ((Array.get _base_length length) + 3 + extra)) inflater
+      in
+
+      read_extra_length (n - 257) inflater
+  in
+
+  get_chr loop inflater
+
+and fixed window inflater =
+  let get_chr next inflater =
+    huffman_read_and_find_get_bit_get_bits
+      fixed_huffman next inflater
+  in
+
+  let get_dst next =
+    get_revbits 5 next
+  in
+
+  inflate window get_chr get_dst inflater
+
+and dynamic window inflater =
+  [%debug Logs.debug @@ fun m -> m "state: dynamic"];
+
+  let make_table hlit hdist hclen buf inflater =
+    [%debug Logs.debug @@ fun m -> m "state: make_table [%d:%d:%d]" hlit hdist hclen];
+    [%debug
+     let print_arr ~sep print_data fmt arr =
+       let rec aux = function
+         | [] -> ()
+         | [ x ] -> print_data fmt x
+         | x :: r -> Format.fprintf fmt "%a%s" print_data x sep; aux r
+       in
+
+       aux (Array.to_list arr)
+     in
+     let print_int = Format.pp_print_int in
+
+     Logs.debug @@ fun m -> m "state: make_table [%a]" (print_arr ~sep:"; " print_int) buf];
+
+    Dictionary.inflate
+      (Huffman.make buf 0 19 7, hlit + hdist)
+      (fun dict inflater ->
+       let huffman_chr = Huffman.make dict 0 hlit 15 in
+       let huffman_dst = Huffman.make dict hlit hdist 15 in
+
+       let get_chr next inflater =
+         huffman_read_and_find_get_bit_get_bits
+           huffman_chr next inflater
+       in
+
+       let get_dst next inflater =
+         huffman_read_and_find_get_bit_get_bits
+           huffman_dst next inflater
+       in
+
+       inflate window get_chr get_dst inflater)
+      inflater
+  in
+  let read_table hlit hdist hclen inflater =
+    let buf = Array.make 19 0 in
+
+    let rec loop iterator code inflater =
+      Array.set buf (Array.get hclen_order iterator) code;
+
+      if iterator + 1 = hclen
+      then begin
+        for i = hclen to 18 do Array.set buf (Array.get hclen_order i) 0 done;
+        make_table hlit hdist hclen buf inflater
+      end else get_bits 3 (loop (iterator + 1)) inflater
+    in
+
+    get_bits 3 (loop 0) inflater
+  in
+  let read_hclen hlit hdist = get_bits 4 (fun hclen -> read_table hlit hdist @@ hclen + 4) in
+  let read_hdist hlit       = get_bits 5 (fun hdist -> read_hclen hlit @@ hdist + 1) in
+  let read_hlit             = get_bits 5 (fun hlit  -> read_hdist @@ hlit + 257) in
+
+  read_hlit inflater
+
+and block window inflater =
+  get_bits 2
+    (fun n inflater ->
+     [%debug Logs.debug @@ fun m -> m "state: block [%d]" n];
+
+     match n with
+     | 0 -> flat window inflater
+     | 1 -> fixed window inflater
+     | 2 -> dynamic window inflater
+     | _ -> raise Invalid_type_of_block)
+    inflater
+
+and last window inflater =
+  get_bit (fun last inflater ->
+           [%debug Logs.debug @@ fun m -> m "state: last [%b]" last];
+
+           inflater.last <- last;
+           block window inflater)
+     inflater
+
+and header inflater =
+  let aux byte0 byte1 inflater =
+    [%debug Logs.debug @@ fun m -> m "state: header [%d:%d]" byte0 byte1];
+
+    let buffer = RW.create_by inflater.dst ((1 lsl (byte0 lsr 4 + 8)) + 1) in
+    let window = Window.create (byte0 lsr 4 + 8) buffer in
+    last window inflater
+  in
+
+  get_byte' (fun byte0 -> get_byte' (fun byte1 -> aux byte0 byte1)) inflater
+
+let make src dst =
+  { src
+  ; dst
+
+  ; last      = false
+  ; hold      = 0
+  ; bits      = 0
+
+  ; outpos    = 0
+  ; needed    = 0
+
+  ; inpos     = 0
+  ; available = 0
+
+  ; k         = header }
+
+let refill off len inflater =
+  inflater.inpos <- off;
+  inflater.available <- off + len
+
+let flush off len inflater =
+  inflater.outpos <- off;
+  inflater.needed <- off + len
+
+let used_in  { inpos; _ } = inpos
+let used_out { outpos; _ } = outpos
+
+let decompress src dst refill' flush' =
+  let inflater = make src dst in
+
+  flush 0 (RW.length dst) inflater;
+
+  let rec aux () = match eval inflater with
+    | Ok ->
+      let drop = flush' dst (used_out inflater) in
+      flush 0 drop inflater
+    | Flush ->
+      let drop = flush' dst (used_out inflater) in
+      flush 0 drop inflater; aux ()
+    | Wait ->
+      let fill = refill' src in
+      refill 0 fill inflater; aux ()
+    | Error -> failwith "Inflate.decompress"
+  in
+
+  aux ()
+
+let string input output refill flush =
+  let input = RO.from_string (Bytes.unsafe_to_string input) in
+  let output = RW.from_bytes output in
+
+  let refill (v : normal RO.t) : int = match v with
+    | RO.String v -> refill (Bytes.unsafe_of_string v) in
+  let flush (v : normal RW.t) : int -> int = match v with
+    | RW.Bytes v -> flush v in
+
+  decompress input output refill flush
+
+let bigstring input output refill flush =
+  let input = RO.from_bigstring input in
+  let output = RW.from_bigstring output in
+
+  let refill (v : fast RO.t) : int = match v with
+    | RO.Bigstring v -> refill v in
+  let flush (v : fast RW.t) : int -> int = match v with
+    | RW.Bigstring v -> flush v in
+
+  decompress input output refill flush

--- a/lib/decompress_inflate.mli
+++ b/lib/decompress_inflate.mli
@@ -1,42 +1,17 @@
-module type INPUT =
-sig
-  type t
+open Decompress_common
 
-  val get  : t -> int -> char
-  val sub  : t -> int -> int -> t
-  val make : int -> char -> t
-end
+type ('i, 'o) t
+and state =
+  | Ok | Flush |  Wait | Error
 
-module type OUTPUT =
-sig
-  type t
-  type i
+val make : 'a RO.t -> 'a RW.t -> ('a, 'a) t
+val eval : ('i, 'o) t -> state
 
-  val create : int -> t
-  val length : t -> int
-  val blit   : t -> int -> t -> int -> int -> unit
-  val iblit  : i -> int -> t -> int -> int -> unit
-  val get    : t -> int -> char
-  val set    : t -> int -> char -> unit
-end
+val flush    : int -> int -> ('i, 'o) t -> unit
+val refill   : int -> int -> ('i, 'o) t -> unit
+val used_in  : ('i, 'o) t -> int
+val used_out : ('i, 'o) t -> int
 
-module type S =
-sig
-  type t
-  type src
-  type dst
-
-  val make : src -> dst -> t
-  val eval : t -> [`Ok | `Flush | `Error | `Wait ]
-
-  val flush    : int -> int -> t -> unit
-  val refill   : int -> int -> t -> unit
-  val used_in  : t -> int
-  val used_out : t -> int
-
-  val decompress : src -> dst -> (src -> int) -> (dst -> int -> int) -> unit
-end
-
-module Make (I : INPUT) (O : OUTPUT with type i = I.t) : S
-  with type dst = O.t
-   and type src = I.t
+val decompress : 'a RO.t -> 'a RW.t -> ('a RO.t -> int) -> ('a RW.t -> int -> int) -> unit
+val string    : bytes -> bytes -> (bytes -> int) -> (bytes -> int -> int) -> unit
+val bigstring : bigstring -> bigstring -> (bigstring -> int) -> (bigstring -> int -> int) -> unit

--- a/lib/decompress_lz77.ml
+++ b/lib/decompress_lz77.ml
@@ -1,636 +1,544 @@
 open Decompress_tables
+open Decompress_common
 
-module type OSCALAR =
-sig
-  type t
-  type i
+let () = [%debug Logs.set_level (Some Logs.Debug)]
+let () = [%debug Logs.set_reporter (Logs_fmt.reporter ())]
 
-  val create   : int -> t
-  val set      : t -> int -> char -> unit
-  val blit     : t -> int -> t -> int -> int -> unit
-  val length   : t -> int
-  val get      : t -> int -> char
-  val get_u16  : t -> int -> int
-  val get_u64  : t -> int -> int64
-  val sub      : t -> int -> int -> t
+type 'a elt =
+  | Buffer of 'a RO.t
+  | Insert of int * int
 
-  val of_input : i -> t
-end
+type 'a t = 'a elt list
 
-module type S =
-sig
-  type buffer
-  type output
-
-  type elt =
-    | Buffer of output
-    | Insert of int * int
-
-  type t = elt list
-
-  val pp_elt          : Format.formatter -> elt -> unit
-  val pp              : Format.formatter -> t -> unit
-
-  type state
-
-  val make            : ?window_bits:int -> ?level:int -> unit -> state
-  val is_empty        : state -> bool
-  val window_bits     : state -> int
-
-  val atomic_compress : state -> buffer -> int -> int -> unit
-  val finish          : state -> (t * int array * int array)
-
-  val compress        : ?window_bits:int -> ?level:int -> ?chunk:int ->
-                        buffer -> int -> int ->
-                        (t * int array * int array)
-end
-
-module Common (OScalar : OSCALAR) =
+module Buffer =
 struct
-  let () = [%debug Logs.set_level (Some Logs.Debug)]
-  let () = [%debug Logs.set_reporter (Logs_fmt.reporter ())]
+  type 'a t =
+    { mutable buffer   : 'a RW.t
+    ; mutable position : int
+    ; mutable length   : int
+    ; initial          : 'a RW.t }
 
-  type buffer = OScalar.i
-  type output = OScalar.t
+  let create proof n =
+    let n = if n < 1 then 1 else n in
+    let n = if n > Sys.max_string_length then Sys.max_string_length else n in
+    let s = RW.create_by proof  n in
+    { buffer = s; position = 0; length = n; initial = s }
 
-  type elt =
-    | Buffer of output
-    | Insert of int * int
+  let contents { buffer; position; _ } = RW.sub_ro buffer 0 position
 
-  type t = elt list
+  let clear buffer = buffer.position <- 0
 
-  let pp_scalar fmt scalar =
-    let l = OScalar.length scalar in
-    for i = 0 to l - 1
-    do Format.fprintf fmt "%c" (OScalar.get scalar i) done
+  let length { position; _ } = position
 
-  let pp_elt fmt = function
-    | Buffer scalar     -> Format.fprintf fmt "Buffer %a" pp_scalar scalar
-    | Insert (off, len) -> Format.fprintf fmt "Insert (%d, %d)" off len
+  let resize buffer more =
+    let len  = buffer.length in
+    let len' = ref len in
 
-  let rec pp fmt l =
-    Format.fprintf fmt "[@[<hov 2> ";
-    List.iter (Format.fprintf fmt "%a;@ " pp_elt) l;
-    Format.fprintf fmt "@]]@;"
+    while buffer.position + more > !len'
+    do len' := 2 * !len' done;
+
+    if !len' > Sys.max_string_length
+    then begin
+      if buffer.position + more <= Sys.max_string_length
+      then len' := Sys.max_string_length
+      else failwith "Buffer.add: cannot grow buffer"
+    end;
+
+    let buffer' = RW.create_by buffer.buffer !len' in
+    RW_ext.blit buffer.buffer 0 buffer' 0 buffer.position;
+    buffer.buffer <- buffer';
+    buffer.length <- !len'
+
+  let add_char buffer chr =
+    let pos = buffer.position in
+    if pos >= buffer.length then resize buffer 1;
+    RW.set buffer.buffer pos chr;
+    buffer.position <- pos + 1
+
+  let empty { position; _ } = position = 0
 end
 
-module Make (OScalar : OSCALAR) : S
-  with type buffer = OScalar.i
-   and type output = OScalar.t =
-struct
-  module Buffer =
-  struct
-    type t =
-      { mutable buffer   : OScalar.t
-      ; mutable position : int
-      ; mutable length   : int
-      ; initial          : OScalar.t }
+module RingBuffer = Decompress_ringbuffer
 
-    let create n =
-      let n = if n < 1 then 1 else n in
-      let n = if n > Sys.max_string_length then Sys.max_string_length else n in
-      let s = OScalar.create n in
-      { buffer = s; position = 0; length = n; initial = s }
+exception Match
+exception Literal
+exception Break
 
-    let contents { buffer; position; _ } = OScalar.sub buffer 0 position
+(* TODO: optimize this! *)
+let repeat atom =
+  let atom = Char.code atom |> Int64.of_int in
+  let ( lor ) = Int64.logor in
+  let ( lsl ) = Int64.shift_left in
+  atom
+  lor (atom lsl 8)
+  lor (atom lsl 16)
+  lor (atom lsl 24)
+  lor (atom lsl 32)
+  lor (atom lsl 40)
+  lor (atom lsl 48)
+  lor (atom lsl 56)
 
-    let clear buffer = buffer.position <- 0
+let hlog = [| 1; 11; 11; 11; 12; 13; 13; 13; 13; 13 |]
 
-    let length { position; _ } = position
+type 'a state =
+  { window_bits    : int
+  ; htab           : int array
+  ; hlog           : int
+  ; level          : int
+  ; buffer         : 'a Buffer.t
+  ; ringbuffer     : 'a RingBuffer.t
+  ; mutable res    : 'a t (* may be avoid that! *)
+  ; freqs_literal  : int array
+  ; freqs_distance : int array }
 
-    let resize buffer more =
-      let len  = buffer.length in
-      let len' = ref len in
+let make ?(window_bits = 15) ?(level = 0) proof =
+  let hlog = try Array.get hlog level with exn -> 1 in
+  let buff = RW.create_by proof ((1 lsl window_bits) + 1) in
+  let res  = { window_bits
+             ; htab       = Array.make (1 lsl hlog) 0
+             ; hlog
+             ; level
+             ; buffer     = Buffer.create proof 64
+             ; ringbuffer = RingBuffer.create (1 lsl window_bits) buff
+             ; res        = []
+             ; freqs_literal  = Array.make 286 0
+             ; freqs_distance = Array.make 30 0 }
+  in res.freqs_literal.(256) <- 1;
+     res
 
-      while buffer.position + more > !len'
-      do len' := 2 * !len' done;
+let is_empty { res; _ } = res = []
+let window_bits { window_bits; _ } = window_bits
 
-      if !len' > Sys.max_string_length
+let really_compress state =
+  let len   = RingBuffer.available_to_read state.ringbuffer in
+  let buff  = RW.create_by state.ringbuffer.RingBuffer.buffer len in
+  let bound = len - 2 in
+  let idx   = ref 0 in
+
+  let i_chr idx = RW.get buff idx in
+  let i_u16 idx = RW.get_u16 buff idx in
+  let i_u64 idx = RW.get_u64 buff idx in
+
+  let r_chr, r_u16, r_u64 =
+    let open RingBuffer in
+
+    let buff = buffer state.ringbuffer in
+    let ( <*  ) chr n = Int64.(shift_left (of_int (Char.code chr)) n) in
+    let ( <|> ) i n   =
+      [%debug Logs.debug @@ fun m -> m "%Ld ^ %Ld" i n];
+      Int64.logor i n in
+
+    (fun idx -> RO.get buff idx),
+    (fun idx ->
+     let r = Char.code @@ RO.get buff (state.ringbuffer % (idx + 1)) in
+     (r lsr 8) lor (Char.code @@ RO.get buff idx)),
+    (fun idx ->
+     let r = ref Int64.zero in
+     let a = ref 0 in
+     let l = (1 lsl state.window_bits) + 1 in
+
+     [%debug Logs.debug @@ fun m -> m "rb_u64, rest = %d" (l - idx)];
+
+     while idx + (!a * 2) < l && idx + (!a * 2) < 8
+     do [%debug Logs.debug @@ fun m -> m "1: rb_64, get character [%c] at %d"
+         (RO.get buff (idx + (!a * 2))) (idx + (!a * 2))];
+
+        r := !r <|> ((RO.get buff (idx + (!a * 2))) <* ((!a * 2) * 8));
+
+        [%debug Logs.debug @@ fun m -> m "2: rb_64, get character [%c] at %d"
+         (RO.get buff (idx + (!a * 2) + 1)) (idx + (!a * 2) + 1)];
+
+        r := !r <|> ((RO.get buff (idx + (!a * 2) + 1)) <* ((!a * 2) * 8 + 8));
+
+        incr a;
+     done;
+
+     [%debug Logs.debug @@ fun m -> m "we read %02d byte(s) for [rb_u64]"
+      (!a * 2)];
+     [%debug Logs.debug @@ fun m -> m "we read %02d byte(s) for [rb_u64]"
+      (8 - (!a * 2))];
+
+     for i = (!a * 2) to 7
+     do [%debug Logs.debug @@ fun m -> m "rb_64, get character [%c] at %d"
+         (RO.get buff RingBuffer.(state.ringbuffer % (idx + i)))
+         (idx + i)];
+        r := !r <|> ((RO.get buff (state.ringbuffer % (idx + i))) <* (i * 8))
+     done;
+
+     !r)
+  in
+
+  let hash idx =
+    let v = i_u16 idx in
+    let v = (i_u16 (idx + 1) lxor (v lsr (16 - state.hlog))) lxor v in
+    v land ((1 lsl state.hlog) - 1)
+  in
+
+  let flushing () =
+    if Buffer.empty state.buffer = false
+    then begin
+      [%debug Logs.debug @@ fun m -> m "we need to flush buffer [%a]"
+       RO.pp (Buffer.contents state.buffer)];
+      state.res <- Buffer (Buffer.contents state.buffer) :: state.res;
+      Buffer.clear state.buffer;
+    end
+  in
+
+  let rpos' = RingBuffer.rpos state.ringbuffer in
+  RingBuffer.peek state.ringbuffer buff 0 len;
+
+  (* we can't predicte something at this time, so we complete the [buffer]. *)
+  state.freqs_literal.(Char.code @@ i_chr !idx) <- state.freqs_literal.(Char.code @@ i_chr !idx) + 1;
+  Buffer.add_char state.buffer (i_chr !idx);
+  incr idx;
+
+  state.freqs_literal.(Char.code @@ i_chr !idx) <- state.freqs_literal.(Char.code @@ i_chr !idx) + 1;
+  Buffer.add_char state.buffer (i_chr !idx);
+  incr idx;
+
+  while !idx < len - 12
+  do
+    [%debug Logs.debug @@ fun m -> m "anchor is %d" !idx];
+
+    let anchor   = !idx in  (* comparison starting-point *)
+    let op       = ref 0 in (* position to old pattern in ring buffer *)
+    let len      = ref 3 in (* length of pattern, minimum match length *)
+    let distance = ref 0 in (* distance of pattern *)
+
+    (* convenience function *)
+    let cmp_and_incr () =
+      [%debug Logs.debug @@ fun m -> m "we compare [%d:%c] == [%d:%c]"
+       !idx (i_chr !idx) !op (r_chr !op)];
+
+      if r_chr !op = i_chr !idx
       then begin
-        if buffer.position + more <= Sys.max_string_length
-        then len' := Sys.max_string_length
-        else failwith "Buffer.add: cannot grow buffer"
+        op  := RingBuffer.(state.ringbuffer % (!op + 1));
+        idx := !idx + 1;
+        true
+      end else false
+    in
+
+    try
+      [%debug
+       let a = Bytes.create 2 in
+       Bytes.set a 0 (i_chr (!idx - 1));
+       Bytes.set a 0 (i_chr !idx);
+       let b = Bytes.create 2 in
+       Bytes.set b 0 (i_chr (!idx + 1));
+       Bytes.set b 0 (i_chr (!idx + 2));
+       Logs.debug @@ fun m -> m "we try a distone match: [%c:%d] = [%c:%d] and [%S:%d] = [%S:%d]"
+         (i_chr !idx) !idx (i_chr (!idx - 1)) (!idx - 1)
+         (Bytes.unsafe_to_string a) (!idx - 1)
+         (Bytes.unsafe_to_string b) (!idx + 1)];
+
+      (* if we have ['a'; 'a'; 'a'; 'a'], so we have a distone match. *)
+      if i_chr !idx = i_chr (!idx - 1)
+         && i_u16 (!idx - 1) = i_u16 (!idx + 1)
+      then begin
+        distance := 1;
+        idx      := !idx + 3;
+        op       := RingBuffer.(state.ringbuffer % (rpos' + anchor + 3));
+
+        raise Match
       end;
 
-      let buffer' = OScalar.create !len' in
-      OScalar.blit buffer.buffer 0 buffer' 0 buffer.position;
-      buffer.buffer <- buffer';
-      buffer.length <- !len'
+      [%debug Logs.debug @@ fun m -> m "we lookup a pattern in hash table"];
+      let hval = hash !idx in
+      let anchor' = RingBuffer.(state.ringbuffer % (rpos' + anchor)) in
 
-    let add_atom buffer atom =
-      let pos = buffer.position in
-      if pos >= buffer.length then resize buffer 1;
-      OScalar.set buffer.buffer pos atom;
-      buffer.position <- pos + 1
+      op       := Array.get state.htab hval;
+      distance :=
+        if anchor' >= !op
+        then anchor' - !op
+        else ((1 lsl state.window_bits) + 1) - (!op - anchor');
+      (* XXX: we need to sanitize distance if the [sanitize_anchor] < [op].
+       * in this case, that means the previous writing in ring buffer update
+       * [rpos] at the begin of (ring) buffer. *)
 
-    let empty { position; _ } = position = 0
-  end
+      [%debug Logs.debug @@ fun m -> m "we have a distance %d with the old \
+        pattern [rpos = %d, anchor = %d, op = %d]"
+       !distance rpos' anchor !op];
 
-  module RingBuffer = Decompress_ringbuffer.Make(Char)(struct type elt = char include OScalar end)
+      if (!distance land 1) = 0 (* TODO, TODO what ? *)
+      then Array.set state.htab hval
+             RingBuffer.(state.ringbuffer % (rpos' + anchor));
 
-  include Common(OScalar)
+      (* if we have a pattern (size of pattern is 3-bytes at least) *)
+      if !distance = 0
+         || !distance >= ((1 lsl state.window_bits) + 8191 - 1)
+            (* XXX: check max far distance. *)
+         || !distance >= (RingBuffer.available_to_write state.ringbuffer)
+            (* XXX: check if the distance is lower than the size of ring
+               buffer. If we don't check that, it's possible to found a
+               pattern of the buff in the buff. *)
+         || cmp_and_incr () = false
+         || cmp_and_incr () = false
+         || cmp_and_incr () = false
+      then raise Literal;
 
-  exception Match
-  exception Literal
-  exception Break
-
-  (* TODO: optimize this! *)
-  let repeat atom =
-    let atom = Char.code atom |> Int64.of_int in
-    let ( lor ) = Int64.logor in
-    let ( lsl ) = Int64.shift_left in
-    atom
-    lor (atom lsl 8)
-    lor (atom lsl 16)
-    lor (atom lsl 24)
-    lor (atom lsl 32)
-    lor (atom lsl 40)
-    lor (atom lsl 48)
-    lor (atom lsl 56)
-
-  let hlog = [| 1; 11; 11; 11; 12; 13; 13; 13; 13; 13 |]
-
-  type state =
-    { window_bits : int
-    ; htab        : int array
-    ; hlog        : int
-    ; level       : int
-    ; buffer      : Buffer.t
-    ; ringbuffer  : RingBuffer.t
-    ; mutable res : t (* may be avoid that! *)
-    ; mutable idx : int
-    ; freqs_literal  : int array
-    ; freqs_distance : int array }
-
-  let make ?(window_bits = 15) ?(level = 0) () =
-    let hlog = try Array.get hlog level with exn -> 1 in
-    let res  = { window_bits
-               ; htab       = Array.make (1 lsl hlog) 0
-               ; hlog
-               ; level
-               ; buffer     = Buffer.create 64
-               ; ringbuffer = RingBuffer.create (1 lsl window_bits)
-               ; res        = []
-               ; idx        = 0
-               ; freqs_literal  = Array.make 286 0
-               ; freqs_distance = Array.make 30 0 }
-    in res.freqs_literal.(256) <- 1;
-       res
-
-  let is_empty { res; _ } = res = []
-  let window_bits { window_bits; _ } = window_bits
-
-  let really_compress state =
-    let len   = RingBuffer.available_to_read state.ringbuffer in
-    let buff  = OScalar.create len in
-    let bound = len - 2 in
-    let ip    = ref 0 in
-
-    (* TODO: may be is useful to use directly and only ringbuffer (we already
-     * save the data in [atomic_compress]). in this case, we need to change
-     * [ip_*] functions.
-     *
-     * The good point is to avoid the allocation of [buff].
-     * The bad point is to sanitize at every moment [ip] (like [op]).
-     *)
-
-    let ip_chr, ip_u16, ip_u64 = OScalar.get buff, OScalar.get_u16 buff, OScalar.get_u64 buff in
-    let rb_chr, rb_u16, rb_u64 =
-      let buff = RingBuffer.to_buffer state.ringbuffer in
-      OScalar.get buff,
-      (fun idx ->
-        let r = (Char.code @@ OScalar.get buff (RingBuffer.sanitize state.ringbuffer (idx + 1))) in
-        (r lsr 8) lor (Char.code @@ OScalar.get buff idx)),
-      (fun idx ->
-        let r = ref Int64.zero in
-        let a = ref 0 in
-        let ( >|< ) atom n =
-          Int64.shift_left
-            (Int64.of_int (Char.code atom)) n in
-        let ( lor ) i n =
-          [%debug Logs.debug @@ fun m -> m "%Ld ^ %Ld"
-            i n];
-          Int64.logor i n in
-        let l = (1 lsl state.window_bits) + 1 in
-        [%debug Logs.debug @@ fun m -> m "rb_u64, rest = %d" (l - idx)];
-
-        while idx + (!a * 2) < l && idx + (!a * 2) < 8
-        do [%debug Logs.debug @@ fun m -> m "1: rb_64, get character [%c] at %d"
-              (OScalar.get buff (idx + (!a * 2))) (idx + (!a * 2))];
-           r := !r lor ((OScalar.get buff (idx + (!a * 2))) >|< ((!a * 2) * 8));
-           [%debug Logs.debug @@ fun m -> m "2: rb_64, get character [%c] at %d"
-              (OScalar.get buff (idx + (!a * 2) + 1)) (idx + (!a * 2) + 1)];
-           r := !r lor ((OScalar.get buff (idx + (!a * 2) + 1)) >|< ((!a * 2) * 8 + 8));
-           incr a;
-        done;
-
-        [%debug Logs.debug @@ fun m -> m "we read %02d byte(s) for [rb_u64]"
-          (!a * 2)];
-        [%debug Logs.debug @@ fun m -> m "we read %02d byte(s) for [rb_u64]"
-          (8 - (!a * 2))];
-
-        for i = (!a * 2) to 7
-        do
-          [%debug Logs.debug @@ fun m -> m "rb_64, get character [%c] at %d"
-            (OScalar.get buff (RingBuffer.sanitize state.ringbuffer (idx + i)))
-            (idx + i)];
-          r := !r lor
-            ((OScalar.get buff (RingBuffer.sanitize state.ringbuffer (idx + i)))
-             >|< (i * 8)); done;
-        !r)
-    in
-
-    let hash idx =
-      let v = ip_u16 idx in
-      let v = (ip_u16 (idx + 1) lxor (v lsr (16 - state.hlog))) lxor v in
-      v land ((1 lsl state.hlog) - 1)
-    in
-
-    let flushing () =
-      if Buffer.empty state.buffer = false
+      (* far, we needs at least 5-bytes *)
+      if state.level >= 5 && !distance >= 8191
       then begin
-        [%debug
-           let o = Buffer.contents state.buffer in
-           let s = Bytes.create (OScalar.length o) in
-           for i = 0 to OScalar.length o - 1
-           do Bytes.set s i (OScalar.get o i) done;
-           Logs.debug @@ fun m -> m "we need to flush buffer [%S]"
-             (Bytes.unsafe_to_string s)];
-        state.res <- Buffer (Buffer.contents state.buffer) :: state.res;
-        Buffer.clear state.buffer;
-      end
-    in
-
-    (* we save the [rpos] (position of begin of [buff] in [ringbuffer])
-     * and blit data in buff. *)
-    let rpos = RingBuffer.rpos state.ringbuffer in
-    RingBuffer.peek state.ringbuffer buff 0 len;
-
-    (* we can't predicte something at this time, so we complete the [buffer]. *)
-    state.freqs_literal.(Char.code @@ ip_chr !ip) <-
-      state.freqs_literal.(Char.code @@ ip_chr !ip) + 1;
-    Buffer.add_atom state.buffer (ip_chr !ip);
-    incr ip;
-    state.freqs_literal.(Char.code @@ ip_chr !ip) <-
-      state.freqs_literal.(Char.code @@ ip_chr !ip) + 1;
-    Buffer.add_atom state.buffer (ip_chr !ip);
-    incr ip;
-
-    while !ip < len - 12 (* we suppress 12 bytes because we read per 8-bytes at
-                            a moment (when we found a pattern) and we limit the
-                            the first boundary (because we search a pattern with
-                            3 bytes at least) and the second boundary (after we
-                            read n * 8 bytes).
-
-                            The algorithm needs 12 bytes to predict something. *)
-    do
-      [%debug Logs.debug @@ fun m -> m "anchor is %d" !ip];
-
-      let anchor   = !ip in   (* comparison starting-point *)
-      let op       = ref 0 in (* position to old pattern in ring buffer *)
-      let len      = ref 3 in (* length of pattern, minimum match length *)
-      let distance = ref 0 in (* distance of pattern *)
-
-      (* convenience function *)
-      let cmp_and_incr () =
-        [%debug Logs.debug @@ fun m -> m "we compare [%d:%c] == [%d:%c]"
-          !ip (ip_chr !ip) !op (rb_chr !op)];
-
-        if rb_chr !op = ip_chr !ip
-        then begin
-          op := RingBuffer.sanitize state.ringbuffer (!op + 1);
-          ip := !ip + 1;
-          true
-        end else false
-      in
-
-      try
-        [%debug
-          let a = Bytes.create 2 in
-          Bytes.set a 0 (ip_chr (!ip - 1));
-          Bytes.set a 0 (ip_chr !ip);
-          let b = Bytes.create 2 in
-          Bytes.set b 0 (ip_chr (!ip + 1));
-          Bytes.set b 0 (ip_chr (!ip + 2));
-          Logs.debug @@ fun m -> m "we try a distone match: [%c:%d] = [%c:%d] and [%S:%d] = [%S:%d]"
-            (ip_chr !ip) !ip (ip_chr (!ip - 1)) (!ip - 1)
-            (Bytes.unsafe_to_string a) (!ip - 1)
-            (Bytes.unsafe_to_string b) (!ip + 1)];
-        (* if we have ['a'; 'a'; 'a'; 'a'], so we have a distone match. *)
-        if ip_chr !ip = ip_chr (!ip - 1)
-           && ip_u16 (!ip - 1) = ip_u16 (!ip + 1)
-        then begin
-          distance := 1;
-          ip       := !ip + 3;
-          op       := RingBuffer.sanitize
-                        state.ringbuffer
-                        (rpos + anchor + 3);
-
-          raise Match
-        end;
-
-        [%debug Logs.debug @@ fun m -> m "we lookup a pattern in hash table"];
-        let hval = hash !ip in
-
-        let sanitize_anchor = RingBuffer.sanitize state.ringbuffer (rpos + anchor) in
-        op       := Array.get state.htab hval;
-        distance :=
-          if sanitize_anchor >= !op then sanitize_anchor - !op
-          else ((1 lsl state.window_bits) + 1) - (!op - sanitize_anchor);
-        (* XXX: we need to sanitize distance if the [sanitize_anchor] < [op].
-         * in this case, that means the previous writing in ring buffer update
-         * [rpos] at the begin of (ring) buffer. *)
-
-        [%debug Logs.debug @@ fun m -> m "we have a distance %d with the old \
-          pattern [rpos = %d, anchor = %d, op = %d]" !distance rpos anchor !op];
-
-        if (!distance land 1) = 0 (* TODO *)
-        then Array.set state.htab hval
-               (RingBuffer.sanitize state.ringbuffer (rpos + anchor));
-
-        (* if we have a pattern (size of pattern is 3-bytes at least) *)
-        if !distance = 0
-           || !distance >= ((1 lsl state.window_bits) + 8191 - 1)
-              (* XXX: check max far distance. *)
-           || !distance >= (RingBuffer.available_to_write state.ringbuffer)
-              (* XXX: check if the distance is lower than the size of ring
-                 buffer. If we don't check that, it's possible to found a
-                 pattern of the buff in the buff. *)
-           || cmp_and_incr () = false
-           || cmp_and_incr () = false
+        if cmp_and_incr () = false
            || cmp_and_incr () = false
         then raise Literal;
 
-        (* far, we needs at least 5-bytes *)
-        if state.level >= 5 && !distance >= 8191
-        then begin
-          if cmp_and_incr () = false
-             || cmp_and_incr () = false
-          then raise Literal;
+        len := !len + 2
+      end;
 
-          len := !len + 2
+      raise Match
+    with
+    | Literal ->
+      [%debug Logs.debug @@ fun m -> m "we have a literal [%c]" (i_chr anchor)];
+
+      state.freqs_literal.(Char.code @@ i_chr anchor) <-
+        state.freqs_literal.(Char.code @@ i_chr anchor) + 1;
+      Buffer.add_char state.buffer (i_chr anchor);
+      idx := anchor + 1;
+
+    | Match ->
+      begin
+        idx      := anchor + !len;
+        distance := !distance - 1;
+
+        (* in this case, we have a distone. we save the [pattern] and compare
+         * per 8 bytes [op] (in [value2]) and [value1] (the 8 first bytes of
+         * [ip]). if the compare fails, we compare per one byte [op] and
+         * pattern (because [value1] is wrong). after, we break to the sanity
+         * compute of [ip] and [op]. *)
+        if !distance = 0
+        then begin
+          [%debug Logs.debug @@ fun m -> m "we have a distone"];
+
+          let pattern  = i_chr (!idx - 1) in
+          let value1   = repeat pattern in
+
+          try begin
+            while !idx < (bound - 8 - 2) && (!idx - 3 - anchor) < 245
+            do
+              let value2 = r_u64 !op in
+
+              [%debug
+               let s = Bytes.create 8 in
+               for i = 0 to 7 do Bytes.set s i (r_chr RingBuffer.(state.ringbuffer % (!op + i))) done;
+               Logs.debug @@ fun m -> m "we compare %Ld <> [%Ld:%d:%S]"
+                 value1 value2 !op (Bytes.unsafe_to_string s)];
+
+              if value1 <> value2
+              then begin
+                (* find the byte that starts to differ *)
+                while !idx < bound && (!idx - 3 - anchor) < 245
+                do
+                   [%debug Logs.debug @@ fun m -> m "we compare [%c:%d] <> [%c]"
+                    (r_chr !op) !op pattern];
+
+                   if r_chr !op <> pattern
+                   then raise Break
+                   else begin
+                     op := RingBuffer.(state.ringbuffer % (!op + 1));
+                     incr idx; end
+                done
+              end else begin
+                op := RingBuffer.(state.ringbuffer % (!op + 8));
+                idx := !idx + 8; end
+            done;
+
+            raise Break
+          end with Break ->
+            (* sanitize [ip] and [op] to lower than [bound]. *)
+            if !idx > bound
+            then begin
+              let bound' = !idx - bound in
+              idx := !idx - bound';
+              op  := RingBuffer.(state.ringbuffer % (!op - bound'));
+            end;
+
+        (* in this case, we compute a general [Insert] value (not a specific
+         * distone). so we check per 8 bytes and if the compare fails, we
+         * compare per one byte [op] and [ip]. after, we break to the sanity
+         * compute of [ip] and [op].
+         *
+         * the diff between compute the distone and general dist is the
+         * access with [ip], in first case, we use [pattern] to avoid the
+         * access in buffer. in other case, we have an access in buffer by
+         * [ip]. *)
+        end else begin
+          [%debug Logs.debug @@ fun m -> m "we have a match"];
+
+          try begin
+            while !idx < (bound - 8 - 2) && (!idx - 3 - anchor) < 245
+            do
+              [%debug Logs.debug @@ fun m -> m "we compare %Ld <> %Ld"
+                (i_u64 !idx) (r_u64 !op)];
+
+              if r_u64 !op <> i_u64 !idx
+              then begin
+                (* find the byte that starts to differ *)
+                while !idx < bound && (!idx - 3 - anchor) < 245
+                do
+                   [%debug Logs.debug @@ fun m -> m "we compare [%d:%c] <> [%d:%c]"
+                    !idx (i_chr !idx) !op (r_chr !op)];
+
+                   if cmp_and_incr () = false then raise Break done;
+
+                raise Break;
+              end else begin op  := RingBuffer.(state.ringbuffer % (!op + 8));
+                             idx := !idx + 8; end
+            done;
+
+            raise Break
+          end with Break ->
+            (* sanitize [ip] and [op] to lower than [bound]. *)
+            if !idx > bound
+            then begin
+              let bound' = !idx - bound in
+
+              idx := !idx - bound';
+              op  := RingBuffer.(state.ringbuffer % (!op - bound'));
+            end
         end;
 
-        raise Match
-      with
-      | Literal ->
-        [%debug Logs.debug @@ fun m -> m "we have a literal [%c]" (ip_chr anchor)];
+        [%debug Logs.debug @@ fun m -> m "we drop the first 3 bytes of [ip = %d]" !idx];
+        idx := !idx - 3;
+        [%debug Logs.debug @@ fun m -> m "we compute len of match: [%d - %d = %d]" !idx anchor (!idx - anchor)];
+        len := !idx - anchor;
 
-        state.freqs_literal.(Char.code @@ ip_chr anchor) <-
-          state.freqs_literal.(Char.code @@ ip_chr anchor) + 1;
-        Buffer.add_atom state.buffer (ip_chr anchor);
-        ip := anchor + 1;
+        flushing ();
 
-      | Match ->
-        begin
-          ip := anchor + !len;
-          distance := !distance - 1;
+        let add_match len distance =
+          [%debug Logs.debug @@ fun m -> m "we write len: %d and distance: %d"
+           len distance];
 
-          (* in this case, we have a distone. we save the [pattern] and compare
-           * per 8 bytes [op] (in [value2]) and [value1] (the 8 first bytes of
-           * [ip]). if the compare fails, we compare per one byte [op] and
-           * pattern (because [value1] is wrong). after, we break to the sanity
-           * compute of [ip] and [op]. *)
-          if !distance = 0
-          then begin
-            [%debug Logs.debug @@ fun m -> m "we have a distone"];
+          let leng = _length.(len) in
+          let dist = _distance distance in
 
-            let pattern  = ip_chr (!ip - 1) in
-            let value1   = repeat pattern in
+          [%debug
+           let s =
+             if distance = 0
+             then
+               let op = RingBuffer.(state.ringbuffer % (!op - 1)) in
+               String.make (len + 3) (r_chr op)
+             else begin
+               let s = Bytes.create (len + 3) in
+               for i = 0 to len + 3 - 1 do
+                 let j = RingBuffer.(state.ringbuffer % (!op - len + i)) in
+                 Bytes.set s i (r_chr j)
+               done;
+               Bytes.unsafe_to_string s
+             end
+           in Logs.debug @@ fun m -> m "we add Insert [%S] (available read: %d) (available write: %d)"
+              s
+              (RingBuffer.available_to_read state.ringbuffer)
+              (RingBuffer.available_to_write state.ringbuffer)];
 
-            try begin
-              while !ip < (bound - 8 - 2) && (!ip - 3 - anchor) < 245
-              do
-                let value2 = rb_u64 !op in
+          state.freqs_literal.(leng + 256 + 1) <- state.freqs_literal.(leng + 256 + 1) + 1;
+          state.freqs_distance.(dist) <- state.freqs_distance.(dist) + 1;
+          state.res <- Insert (distance, len) :: state.res;
+        in
 
-                [%debug
-                  let s = Bytes.create 8 in
-                  for i = 0 to 7 do Bytes.set s i (rb_chr (RingBuffer.sanitize state.ringbuffer (!op + i))) done;
-                  Logs.debug @@ fun m -> m "we compare %Ld <> [%Ld:%d:%S]"
-                    value1 value2 !op (Bytes.unsafe_to_string s)];
+        let add_literal chr =
+          state.freqs_literal.(Char.code chr) <- state.freqs_literal.(Char.code chr) + 1;
+          Buffer.add_char state.buffer chr;
+        in
 
-                if value1 <> value2
-                then begin
-                  (* find the byte that starts to differ *)
-                  while !ip < bound && (!ip - 3 - anchor) < 245
-                  do [%debug Logs.debug @@ fun m -> m "we compare [%c:%d] <> [%c]"
-                       (rb_chr !op) !op pattern];
+        [%debug Logs.debug @@ fun m -> m "we found length: %d and distance: %d"
+         !len !distance];
 
-                     if rb_chr !op <> pattern
-                     then raise Break
-                     else begin
-                       op := RingBuffer.sanitize state.ringbuffer (!op + 1);
-                       incr ip; end
-                  done
-                end else begin
-                  op := RingBuffer.sanitize state.ringbuffer (!op + 8);
-                  ip := !ip + 8; end
-              done;
+        (** TODO: I limit the len to 245 + 8 + 2 = 255 in distone or dist
+            match because the max of length is 255. BUT, I try to add multiple
+            [Insert] if the length > 255 and we have 3 cases (I think):
 
-              raise Break
-            end with Break ->
-              (* sanitize [ip] and [op] to lower than [bound]. *)
-              if !ip > bound
-              then begin
-                let bound' = !ip - bound in
-                ip := !ip - bound';
-                op := RingBuffer.sanitize state.ringbuffer (!op - bound');
-              end;
+            * The first case is if [length mod 255] >= 3 because a [Insert]
+              block need 3 bytes before (see Lz77 compression).
+            * The second case is if [length mod 255] < 3. In this case, we add
+              after the last [Insert] block [length mod 255] literal(s) to
+              complete the data.
+            * The last case is [length < 256], it's a cool and simple case.
 
-          (* in this case, we compute a general [Insert] value (not a specific
-           * distone). so we check per 8 bytes and if the compare fails, we
-           * compare per one byte [op] and [ip]. after, we break to the sanity
-           * compute of [ip] and [op].
-           *
-           * the diff between compute the distone and general dist is the
-           * access with [ip], in first case, we use [pattern] to avoid the
-           * access in buffer. in other case, we have an access in buffer by
-           * [ip]. *)
-          end else begin
-            [%debug Logs.debug @@ fun m -> m "we have a match"];
+            So, the code (except the third case) is dead. But if I have a time
+            to do this, I have a PoC.
+        *)
+        if !len > 255 && (!len mod 255) >= 3
+        then begin
+          [%debug Logs.debug @@ fun m -> m "multiple insert, we have len %d > 255 and (len mod 255) >= 3, the distance is %d" !len !distance];
+          let times = !len / 255 in
+          for i = 0 to times - 1
+          do add_match 255 !distance done;
 
-            try begin
-              while !ip < (bound - 8 - 2) && (!ip - 3 - anchor) < 245
-              do
-                [%debug Logs.debug @@ fun m -> m "we compare %Ld <> %Ld"
-                  (ip_u64 !ip) (rb_u64 !op)];
+          add_match (!len mod 255) !distance
+        end else if !len > 255 && (!len mod 255) < 3
+        then begin
+          [%debug Logs.debug @@ fun m -> m "multiple insert, we have len %d > 255 and (len mod 255) < 3, the distance is %d" !len !distance];
+          let times = !len / 255 in
+          for i = 0 to times - 1
+          do add_match 255 !distance done;
 
-                if rb_u64 !op <> ip_u64 !ip
-                then begin
-                  (* find the byte that starts to differ *)
-                  while !ip < bound && (!ip - 3 - anchor) < 245
-                  do [%debug Logs.debug @@ fun m -> m "we compare [%d:%c] <> [%d:%c]"
-                       !ip (ip_chr !ip) !op (rb_chr !op)];
+          let times = !len mod 255 in
+          for i = 0 to times - 1
+          do add_literal (r_chr (RingBuffer.(state.ringbuffer % (!op - i)))) done;
+        end else begin
+          add_match !len !distance
+        end;
 
-                     if cmp_and_incr () = false then raise Break done;
+        (* update the match at match boundary *)
+        Array.set state.htab (hash !idx)
+          RingBuffer.(state.ringbuffer % (rpos' + !idx));
+        incr idx;
+        Array.set state.htab (hash !idx)
+          RingBuffer.(state.ringbuffer % (rpos' + !idx));
+        incr idx;
+        Array.set state.htab (hash !idx)
+          RingBuffer.(state.ringbuffer % (rpos' + !idx));
+        incr idx;
+    end
+  done;
 
-                  raise Break;
-                end else begin op := RingBuffer.sanitize state.ringbuffer (!op + 8); ip := !ip + 8; end
-              done;
+  RingBuffer.drop state.ringbuffer !idx
 
-              raise Break
-            end with Break ->
-              (* sanitize [ip] and [op] to lower than [bound]. *)
-              if !ip > bound
-              then begin
-                let bound' = !ip - bound in
+let atomic_compress state buff off len =
+  RingBuffer.write_ro state.ringbuffer buff off len;
 
-                ip := !ip - bound';
-                op := RingBuffer.sanitize state.ringbuffer (!op - bound');
-              end
-          end;
+  if RingBuffer.available_to_read state.ringbuffer > 12
+  then really_compress state
 
-          [%debug Logs.debug @@ fun m -> m "we drop the first 3 bytes of [ip = %d]" !ip];
-          ip  := !ip - 3;
-          [%debug Logs.debug @@ fun m -> m "we compute len of match: [%d - %d = %d]" !ip anchor (!ip - anchor)];
-          len := !ip - anchor;
+let finish state =
+  [%debug Logs.debug @@ fun m -> m "we have a rest: %d byte(s)"
+    (RingBuffer.available_to_read state.ringbuffer)];
 
-          flushing ();
+  if RingBuffer.available_to_read state.ringbuffer > 12
+  then really_compress state;
 
-          let add_match len distance =
-            [%debug Logs.debug @@ fun m -> m "we write len: %d and distance: %d"
-              len distance];
-            [%debug assert (len >= 0 && len < 256)];
+  if RingBuffer.available_to_read state.ringbuffer > 0
+  then begin
+    while RingBuffer.available_to_read state.ringbuffer > 0
+    (* TODO: replace by transmit *)
+    do let _ = RingBuffer.transmit state.ringbuffer
+         (fun buff off len ->
+          let i = ref 0 in
+          while !i < len do
+            let e = RW.get buff (off + !i) in
+            state.freqs_literal.(Char.code e) <-
+              state.freqs_literal.(Char.code e) + 1;
 
-            let leng = _length.(len) in
-            let dist = _distance distance in
-
-            state.freqs_literal.(leng + 256 + 1) <-
-              state.freqs_literal.(leng + 256 + 1) + 1;
-            state.freqs_distance.(dist) <- state.freqs_distance.(dist) + 1;
-
-            [%debug
-              let s =
-                if distance = 0
-                then
-                  let op = RingBuffer.sanitize state.ringbuffer (!op - 1) in
-                  String.make (len + 3) (rb_chr op)
-                else begin
-                  let s = Bytes.create (len + 3) in
-                  for i = 0 to len + 3 - 1 do
-                  Logs.debug @@ fun m -> m "we get the character at [%d - %d + %d = %d]" !op len i (!op - len + i);
-                    let j = RingBuffer.sanitize state.ringbuffer (!op - len + i) in
-                    Bytes.set s i (rb_chr j) done;
-                  Bytes.unsafe_to_string s
-                end
-              in
-              Logs.debug @@ fun m -> m "we add Insert [%S] at %d (available read: %d) (available write: %d)"
-                s (state.idx + anchor)
-                (RingBuffer.available_to_read state.ringbuffer)
-                (RingBuffer.available_to_write state.ringbuffer)];
-
-            state.res <- Insert (distance, len) :: state.res;
-          in
-
-          let add_literal chr =
-            state.freqs_literal.(Char.code chr) <-
-              state.freqs_literal.(Char.code chr) + 1;
-            Buffer.add_atom state.buffer chr;
-          in
-
-          [%debug Logs.debug @@ fun m -> m "we found length: %d and distance: %d"
-            !len !distance];
-
-          (** TODO: I limit the len to 245 + 8 + 2 = 255 in distone or dist
-              match because the max of length is 255. BUT, I try to add multiple
-              [Insert] if the length > 255 and we have 3 cases (I think):
-
-              * The first case is if [length mod 255] >= 3 because a [Insert]
-                block need 3 bytes before (see Lz77 compression).
-              * The second case is if [length mod 255] < 3. In this case, we add
-                after the last [Insert] block [length mod 255] literal(s) to
-                complete the data.
-              * The last case is [length < 256], it's a cool and simple case.
-
-              So, the code (except the third case) is dead. But if I have a time
-              to do this, I have a PoC.
-          *)
-          if !len > 255 && (!len mod 255) >= 3
-          then begin
-            [%debug Logs.debug @@ fun m -> m "multiple insert, we have len %d > 255 and (len mod 255) >= 3, the distance is %d" !len !distance];
-            let times = !len / 255 in
-            for i = 0 to times - 1
-            do add_match 255 !distance done;
-
-            add_match (!len mod 255) !distance
-          end else if !len > 255 && (!len mod 255) < 3
-          then begin
-            [%debug Logs.debug @@ fun m -> m "multiple insert, we have len %d > 255 and (len mod 255) < 3, the distance is %d" !len !distance];
-            let times = !len / 255 in
-            for i = 0 to times - 1
-            do add_match 255 !distance done;
-
-            let times = !len mod 255 in
-            for i = 0 to times - 1
-            do add_literal (rb_chr (RingBuffer.sanitize state.ringbuffer (!op - i))) done;
-          end else begin
-            add_match !len !distance
-          end;
-
-          (* update the match at match boundary *)
-          Array.set state.htab (hash !ip)
-            (RingBuffer.sanitize state.ringbuffer (rpos + !ip));
-          incr ip;
-          Array.set state.htab (hash !ip)
-            (RingBuffer.sanitize state.ringbuffer (rpos + !ip));
-          incr ip;
-          Array.set state.htab (hash !ip)
-            (RingBuffer.sanitize state.ringbuffer (rpos + !ip));
-          incr ip;
-      end
+            Buffer.add_char state.buffer e;
+            incr i;
+          done; len)
+       in ()
     done;
 
-    [%debug state.idx <- state.idx + !ip];
-    RingBuffer.drop state.ringbuffer !ip
+    state.res <- Buffer (Buffer.contents state.buffer) :: state.res
+  end;
 
-  let atomic_compress state buff off len =
-    RingBuffer.write state.ringbuffer (OScalar.of_input buff) off len;
+  List.rev state.res, state.freqs_literal, state.freqs_distance
 
-    if RingBuffer.available_to_read state.ringbuffer > 12
-    then really_compress state
-    else ()
+let compress ?(window_bits = 15) ?(level = 0) ?(chunk = (1 lsl 5)) proof buff off len =
+  let n = len / chunk in
+  let s = make ~window_bits ~level proof in
+  let r = ref len in
 
-  let finish state =
-    [%debug Logs.debug @@ fun m -> m "we have a rest: %d byte(s)"
-      (RingBuffer.available_to_read state.ringbuffer)];
+  for i = 0 to n
+  do atomic_compress s buff (i * chunk) (min chunk !r);
+     r := !r - (1 lsl 5);
+     r := if !r < 0 then 0 else !r; done;
 
-    if RingBuffer.available_to_read state.ringbuffer > 12
-    then really_compress state;
-
-    if RingBuffer.available_to_read state.ringbuffer > 0
-    then begin
-      let len = RingBuffer.available_to_read state.ringbuffer in
-
-      [%debug Logs.debug @@ fun m -> m "we finish and we had %d byte(s) to the \
-        last buffer" len];
-
-      let s = OScalar.create len in
-      RingBuffer.read state.ringbuffer s 0 len;
-
-      for i = 0 to len - 1
-      do
-        (* we update frequencies with the last buffer. *)
-        let e = OScalar.get s i in
-        state.freqs_literal.(Char.code e) <-
-          state.freqs_literal.(Char.code e) + 1;
-
-        Buffer.add_atom state.buffer e
-      done;
-
-      state.res <- Buffer (Buffer.contents state.buffer) :: state.res;
-    end;
-
-    List.rev state.res, state.freqs_literal, state.freqs_distance
-
-  let compress ?(window_bits = 15) ?(level = 0) ?(chunk = (1 lsl 5)) buff off len =
-    let n = len / chunk in
-    let s = make ~window_bits ~level () in
-    let r = ref len in
-
-    for i = 0 to n
-    do atomic_compress s buff (i * chunk) (min chunk !r);
-       r := !r - (1 lsl 5);
-       r := if !r < 0 then 0 else !r; done;
-
-    finish s
-end
+  finish s

--- a/lib/decompress_ringbuffer.ml
+++ b/lib/decompress_ringbuffer.ml
@@ -1,166 +1,153 @@
-module type ATOM =
-sig
-  type t
-end
+open Decompress_common
 
-module type SCALAR =
-sig
-  type elt
-  type t
+type 'a t =
+  { mutable rpos : int
+  ; mutable wpos : int
+  ; size         : int
+  ; buffer       : 'a RW.t }
 
-  val create : int -> t
-  val blit   : t -> int -> t -> int -> int -> unit
-  val get    : t -> int -> elt
-  val set    : t -> int -> elt -> unit
-end
+let create size buffer =
+  assert (RW.length buffer >= size + 1);
 
-module type S =
-sig
-  type t
-  type atom
-  type buffer
+  { rpos = 0
+  ; wpos = 0
+  ; size = size + 1
+  ; buffer }
 
-  val create : int -> t
-  val available_to_read  : t -> int
-  val available_to_write : t -> int
+let available_to_read t =
+  if t.wpos >= t.rpos then (t.wpos - t.rpos)
+  else t.size - (t.rpos - t.wpos)
 
-  val drop : t -> int -> unit
-  val move : t -> int -> unit
+let available_to_write t =
+  if t.wpos >= t.rpos then t.size - (t.wpos - t.rpos) - 1
+  else (t.rpos - t.wpos) - 1
 
-  val peek  : t -> buffer -> int -> int -> unit
-  val read  : t -> buffer -> int -> int -> unit
-  val write : t -> buffer -> int -> int -> unit
+let drop t n =
+  assert (n <= available_to_read t);
+  if t.rpos + n < t.size then t.rpos <- t.rpos + n
+  else t.rpos <- t.rpos + n - t.size
 
-  val rpos  : t -> int
-  val wpos  : t -> int
-  val sanitize : t -> int -> int
+let transmit t f =
+  if t.wpos = t.rpos then 0
+  else
+    let len0 =
+      if t.wpos >= t.rpos then t.wpos - t.rpos
+      else t.size - t.rpos
+    in
+    let len = f t.buffer t.rpos len0 in
+    assert (len <= len0);
+    drop t len;
+    len
 
-  val rget : t -> int -> atom
-  val rsub : t -> int -> int -> buffer
+let move t n =
+  assert (n <= available_to_write t);
 
-  val to_buffer : t -> buffer
-end
+  if t.wpos + n < t.size then t.wpos <- t.wpos + n
+  else t.wpos <- t.wpos + n - t.size
 
-module Make (Atom : ATOM) (Scalar : SCALAR with type elt = Atom.t) : S
-  with type atom = Atom.t
-   and type buffer = Scalar.t =
-struct
-  let () = [%debug Logs.set_level (Some Logs.Debug)]
-  let () = [%debug Logs.set_reporter (Logs_fmt.reporter ())]
+let peek t buff off len =
+  assert (len <= available_to_read t);
 
-  type t =
-    { mutable rpos : int
-    ; mutable wpos : int
-    ; size         : int
-    ; buffer       : Scalar.t }
+  let pre = t.size - t.rpos in
+  let extra = len - pre in
+  if extra > 0 then begin
+    RW_ext.blit t.buffer t.rpos buff off pre;
+    RW_ext.blit t.buffer 0 buff (off + pre) extra;
+  end else
+    RW_ext.blit t.buffer t.rpos buff off len
 
-  type atom = Atom.t
-  type buffer = Scalar.t
+let read t buff off len =
+  peek t buff off len;
+  drop t len
 
-  let create size =
-    { rpos = 0
-    ; wpos = 0
-    ; size = size + 1
-    ; buffer = Scalar.create (size + 1) }
+let write_string t buff off len =
+  if len > available_to_write t
+  then drop t (len - (available_to_write t));
 
-  let available_to_read t =
-    if t.wpos >= t.rpos then (t.wpos - t.rpos)
-    else t.size - (t.rpos - t.wpos)
+  assert (len <= available_to_write t);
 
-  let available_to_write t =
-    if t.wpos >= t.rpos then t.size - (t.wpos - t.rpos) - 1
-    else (t.rpos - t.wpos) - 1
+  let pre = t.size - t.wpos in
+  let extra = len - pre in
+  if extra > 0 then begin
+    RW_ext.blit_string buff off t.buffer t.wpos pre;
+    RW_ext.blit_string buff (off + pre) t.buffer 0 extra;
+  end else
+    RW_ext.blit_string buff off t.buffer t.wpos len;
 
-  let drop t n =
-    assert (n <= available_to_read t);
-    if t.rpos + n < t.size then t.rpos <- t.rpos + n
-    else t.rpos <- t.rpos + n - t.size
+  move t len
 
-  let transmit t f =
-    if t.wpos = t.rpos then 0
-    else
-      let len0 =
-        if t.wpos >= t.rpos then t.wpos - t.rpos
-        else t.size - t.rpos
-      in
-      let len = f t.buffer t.rpos len0 in
-      assert (len <= len0);
-      drop t len;
-      len
+let write_ro t buff off len =
+  if len > available_to_write t
+  then drop t (len - (available_to_write t));
 
-  let pp fmt t =
-    if t.rpos <= t.wpos
-    then Format.fprintf fmt "[ rpos: %d; ... wpos: %d; ]" t.rpos t.wpos
-    else Format.fprintf fmt "[ wpos: %d; ... rpos: %d; ]" t.wpos t.rpos
+  assert (len <= available_to_write t);
 
-  let move t n =
-    assert (n <= available_to_write t);
-    if t.wpos + n < t.size then t.wpos <- t.wpos + n
-    else t.wpos <- t.wpos + n - t.size
+  let pre = t.size - t.wpos in
+  let extra = len - pre in
+  if extra > 0 then begin
+    RW_ext.blit_ro buff off t.buffer t.wpos pre;
+    RW_ext.blit_ro buff (off + pre) t.buffer 0 extra;
+  end else
+    RW_ext.blit_ro buff off t.buffer t.wpos len;
 
-  let peek t buff off len =
-    assert (len <= available_to_read t);
+  move t len
 
-    let pre = t.size - t.rpos in
-    let extra = len - pre in
-    if extra > 0 then begin
-      Scalar.blit t.buffer t.rpos buff off pre;
-      Scalar.blit t.buffer 0 buff (off + pre) extra;
-    end else
-      Scalar.blit t.buffer t.rpos buff off len
+let write_char t chr =
+  if 1 > available_to_write t
+  then drop t (1 - (available_to_write t));
 
-  let read t buff off len =
-    peek t buff off len;
-    drop t len
+  assert (1 <= available_to_write t);
+  assert (t.wpos <> t.size);
 
-  let write t buff off len =
-    (* XXX: if we have no space to write, we drop data!
-            may be this compute must be in [Decompress.Window]. *)
-    if len > available_to_write t
-    then drop t (len - (available_to_write t));
+  RW.set t.buffer t.wpos chr;
+  move t 1
 
-    assert (len <= available_to_write t);
+let fill t chr len =
+  if len > available_to_write t
+  then drop t (len - (available_to_write t));
 
-    let pre = t.size - t.wpos in
-    let extra = len - pre in
-    if extra > 0 then begin
-      Scalar.blit buff off t.buffer t.wpos pre;
-      Scalar.blit buff (off + pre) t.buffer 0 extra;
-    end else
-      Scalar.blit buff off t.buffer t.wpos len;
+  assert (len <= available_to_write t);
 
-    move t len
+  let pre = t.size - t.wpos in
+  let extra = len - pre in
+  if extra > 0 then begin
+    RW.fill t.buffer t.wpos pre chr;
+    RW.fill t.buffer 0 extra chr;
+  end else
+    RW.fill t.buffer t.wpos len chr;
 
-  let wpos t = t.wpos
-  let rpos t = t.rpos
+  move t len
 
-  let rec sanitize t i =
-    if i >= 0 && i < t.size then i
-    else if i > t.size then sanitize t (i - t.size)
-    else sanitize t (t.size - i)
+let wpos t = t.wpos
+let rpos t = t.rpos
 
-  let rget t idx =
-    (* TODO: assert (idx < available_to_read t);
-     * it's not good assertion, so we need to found another assertion with
-     * [rget]. *)
-    let pre = t.wpos - idx in
-    let pos = t.size - (abs pre) in
-    if pre < 0
-    then Scalar.get t.buffer pos
-    else Scalar.get t.buffer pre
+let rec sanitize t i =
+  if i < 0 then sanitize t (t.size + i)
+  else if i >= 0 && i < t.size then i
+  else sanitize t (i - t.size)
+(* XXX: we need to optimize that. *)
 
-  let rsub t off len =
-    assert (off < available_to_read t);
+let transmit t f =
+  if t.wpos = t.rpos then 0
+  else let len0 =
+         if t.wpos >= t.rpos then t.wpos - t.rpos
+         else t.size - t.rpos
+       in
+       (* XXX: t.buffer to read-only? *)
+       let len = f t.buffer t.rpos len0 in
+       assert (len <= len0);
+       drop t len;
+       len
 
-    let buff = Scalar.create len in
+let read_space t =
+  if t.wpos = t.rpos then None
+  else let len0 =
+         if t.wpos >= t.rpos then t.wpos - t.rpos
+         else t.size - t.rpos
+       in
 
-    let pre = t.wpos - off in
-    let pos = if pre < 0 then t.size + (* - *) pre else pre in
+       Some (to_ro t.buffer, t.rpos, len0)
 
-    for i = 0 to len
-    do Scalar.set buff 0 (Scalar.get t.buffer (sanitize t (pos + i))) done;
+let ( % ) = sanitize
 
-    buff
-
-  let to_buffer { buffer; _ } = buffer
-end
+let buffer { buffer; _ } = to_ro buffer

--- a/lib/decompress_ringbuffer.mli
+++ b/lib/decompress_ringbuffer.mli
@@ -1,46 +1,31 @@
-module type ATOM =
-sig
-  type t
-end
+open Decompress_common
 
-module type SCALAR =
-sig
-  type elt
-  type t
+type 'a t =
+  { mutable rpos       : int
+  ; mutable wpos       : int
+  ; size               : int
+  ; buffer             : 'a RW.t }
 
-  val create : int -> t
-  val blit   : t -> int -> t -> int -> int -> unit
-  val get    : t -> int -> elt
-  val set    : t -> int -> elt -> unit
-end
+val create             : int -> 'a RW.t -> 'a t
+val available_to_read  : 'a t -> int
+val available_to_write : 'a t -> int
 
-module type S =
-sig
-  type t
-  type atom
-  type buffer
+val drop               : 'a t -> int -> unit
+val move               : 'a t -> int -> unit
 
-  val create : int -> t
-  val available_to_read  : t -> int
-  val available_to_write : t -> int
+val peek               : 'a t -> 'a RW.t -> int -> int -> unit
+val read               : 'a t -> 'a RW.t -> int -> int -> unit
+val write_string       : 'a t -> string -> int -> int -> unit
+val write_ro           : 'a t -> 'a RO.t -> int -> int -> unit
+val write_char         : 'a t -> char -> unit
+val fill               : 'a t -> char -> int -> unit
+val transmit           : 'a t -> ('a RW.t -> int -> int -> int) -> int
 
-  val drop : t -> int -> unit
-  val move : t -> int -> unit
+val rpos               : 'a t -> int
+val wpos               : 'a t -> int
 
-  val peek  : t -> buffer -> int -> int -> unit
-  val read  : t -> buffer -> int -> int -> unit
-  val write : t -> buffer -> int -> int -> unit
+val read_space         : 'a t -> ('a RO.t * int * int) option
 
-  val rpos : t -> int
-  val wpos : t -> int
-  val sanitize : t -> int -> int
+val ( % )              : 'a t -> int -> int
 
-  val rget : t -> int -> atom
-  val rsub : t -> int -> int -> buffer
-
-  val to_buffer : t -> buffer
-end
-
-module Make (Atom : ATOM) (Scalar : SCALAR with type elt = Atom.t) : S
-  with type atom = Atom.t
-   and type buffer = Scalar.t
+val buffer             : 'a t -> 'a RO.t

--- a/lib_test/decompress_test.ml
+++ b/lib_test/decompress_test.ml
@@ -90,8 +90,6 @@ open Decompress
 
 module Inflate =
 struct
-  include Inflate.Make(ExtString)(ExtBytes)
-
   let string str size_i size_o =
     let i = Bytes.create size_i in
     let o = Bytes.create size_o in
@@ -101,8 +99,8 @@ struct
       let n = String.length input in
       let to_read = ref n in
       fun buf ->
-        let m = min !to_read (String.length buf) in
-        String.blit input (n - !to_read) (Bytes.unsafe_of_string buf) 0 m;
+        let m = min !to_read (Bytes.length buf) in
+        String.blit input (n - !to_read) buf 0 m;
         to_read := !to_read - m;
         m
     in
@@ -111,14 +109,12 @@ struct
       Buffer.add_subbytes output buf 0 len; len
     in
 
-    decompress (Bytes.unsafe_to_string i) o (refill str) (flush uncompressed);
+    Inflate.string i o (refill str) (flush uncompressed);
     Buffer.contents uncompressed
 end
 
 module Deflate =
 struct
-  include Deflate.Make(ExtString)(ExtBytes)
-
   let string str size_i size_o level =
     let i = Bytes.create size_i in
     let o = Bytes.create size_o in
@@ -127,8 +123,8 @@ struct
     let size = String.length str in
 
     let refill' input =
-      let n = min (size - !position) (String.length input) in
-      String.blit str !position (Bytes.unsafe_of_string input) 0 n;
+      let n = min (size - !position) (Bytes.length input) in
+      String.blit str !position input 0 n;
       position := !position + n;
       if !position >= size then true, n else false, n
     in
@@ -138,7 +134,7 @@ struct
       size
     in
 
-    compress ~level (Bytes.unsafe_to_string i) o refill' flush';
+    Deflate.string ~level i o refill' flush';
     Buffer.contents compressed
 end
 
@@ -245,6 +241,6 @@ let test_strings number =
 
 let () =
   Alcotest.run "Decompress test"
-    [ "random string", test_strings 25
-    ; "decompress files", test_files "./lib_test/files/"
+    (* [ "random string", test_strings 25 *)
+    [ "decompress files", test_files "./lib_test/files/"
     ; "bin files", test_files "/bin/" ]

--- a/memcpy/memcpy.ml
+++ b/memcpy/memcpy.ml
@@ -1,0 +1,10 @@
+open Bigarray
+
+type bigstring = (char, int8_unsigned_elt, c_layout) Array1.t
+
+external memcpy_bytes
+  : bytes -> bytes -> int -> int -> int -> unit
+  = "memcpy_bytes"
+external memcpy_bigstring
+  : bigstring -> bigstring -> int -> int -> int -> unit
+  = "memcpy_bigstring"

--- a/memcpy/memcpy.mli
+++ b/memcpy/memcpy.mli
@@ -1,0 +1,6 @@
+open Bigarray
+
+type bigstring = (char, int8_unsigned_elt, c_layout) Array1.t
+
+val memcpy_bytes : bytes -> bytes -> int -> int -> int -> unit
+val memcpy_bigstring : bigstring -> bigstring -> int -> int -> int -> unit

--- a/memcpy/stub_memcpy.c
+++ b/memcpy/stub_memcpy.c
@@ -1,0 +1,74 @@
+#if defined(STDC) && !defined(SOLO)
+#  if !(defined(_WIN32_WCE) && defined(_MSC_VER))
+#    include <stddef.h>
+#  endif
+#  include <string.h>
+#  include <stdlib.h>
+#endif
+
+#if defined(SOLO)
+#  define NO_MEMCPY
+#endif
+#if defined(SMALL_MEDIUM) && !defined(_MSC_VER) && !defined(__SC__)
+#  define NO_MEMCPY
+#endif
+#if defined(STDC) && !defined(HAVE_MEMCPY) && !defined(NO_MEMCPY)
+#  define HAVE_MEMCPY
+#endif
+
+#ifdef HAVE_MEMCPY
+#  ifdef SMALL_MEDIUM
+#    define dmemcpy _fmemcpy
+#  else
+#    define dmemcpy memcpy
+#endif
+#else
+  void dmemcpy(char *dst, const char *src, unsigned int len);
+#endif
+
+void dmemcpy(char *dst, const char * src, unsigned int len)
+{
+  if (len == 0) return;
+
+  do {
+    *dst++ = *src++;
+  } while (--len != 0);
+}
+
+#include <stdio.h>
+
+static void dmemcpy_with_offsets(char *dst, const char *src, unsigned int len, int dst_off, int src_off)
+{
+  dmemcpy(dst + dst_off, src + src_off, len);
+}
+
+#include <caml/memory.h>
+#include <caml/bigarray.h>
+
+CAMLprim
+value memcpy_bytes(value src, value dst, value len, value src_off, value dst_off)
+{
+  char *dst_        = String_val(dst);
+  char *src_        = String_val(src);
+  int dst_off_      = Int_val(dst_off);
+  int src_off_      = Int_val(src_off);
+  unsigned int len_ = Int_val(len);
+
+  dmemcpy_with_offsets(dst_, src_, len_, dst_off_, src_off_);
+
+  return Val_unit;
+}
+
+CAMLprim
+value memcpy_bigstring(value src, value dst, value len, value src_off, value dst_off)
+{
+  char *dst_        = Caml_ba_data_val(dst);
+  char *src_        = Caml_ba_data_val(dst);
+  int dst_off_      = Int_val(dst_off);
+  int src_off_      = Int_val(src_off);
+  unsigned int len_ = Int_val(len);
+
+  dmemcpy_with_offsets(dst_, src_, len_, dst_off_, src_off_);
+
+  return Val_unit;
+}

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -91,7 +91,6 @@ struct
 
       (* deps *)
       let stub = env "%(path)lib%(libname).stub" in
-      let libname = env (Pathname.add_extension "cmxa" "%(path)%(libname)") in
 
       let objs = string_list_of_file stub in
       let tags = List.fold_left

--- a/opam
+++ b/opam
@@ -22,7 +22,6 @@ build-test: [
     "--%{base-unix:enable}%-unix"
     "--%{cmdliner:enable}%-cmdliner"
     "--%{camlzip:enable}%-camlzip"
-    "--enable-stub"
     "--prefix=%{prefix}%"]
   [make "test"]
 ]


### PR DESCRIPTION
It's a defunctorization of Decompress (to may be help the compiler to specialize the compute) and add of `memcpy` function instead `memmove`. I win 2 Mb/s in inflate and we lost 2 Mb/s in deflate (but I know why we lost that) - flambda can't optimize the code (with `-O3` we lost 2 Mb/s in inflate, so we come back to the PR #13).

About the lost in deflate, it is due to a big allocation of a buffer (and a copy of the ring-buffer to this buffer to have a continuous buffer) in Lz77 compression and, I think, I can avoid that. I have a another optimization in inflate: is to use a BIG loop with too many reference and may be we win some Mb/s.

PS: to be clear, for this PR I expected a good improvement ... But it's not the case.
PPS: some tests fails and I know why, I will fix that tomorrow
