### PR TITLE
Inffast

### DIFF
--- a/bench.ml
+++ b/bench.ml
@@ -1,0 +1,107 @@
+#!/usr/bin/env utop
+
+#require "perf";;
+#require "ppx_deriving.show";;
+#require "cmdliner";;
+
+let binary_pipe =
+  [ "zpipe"; "dpipe.native" ];;
+
+type e =
+  { process_status : Unix.process_status [@printer fun fmt _ -> fprintf fmt "#process_status"]
+  ; stdout         : string [@printer fun fmt _ -> fprintf fmt "#stdout"]
+  ; stderr         : string
+  ; duration       : Int64.t } [@@deriving show]
+
+type error = exn [@printer fun fmt _ -> fprintf fmt "exn"] [@@deriving show]
+
+type r =
+  [ `Ok of e | `Timeout | `Error of error ] [@@deriving show]
+
+let string_of_ic ic = really_input_string ic @@ in_channel_length ic
+
+let string_of_file filename =
+  let ic = open_in filename in
+  try let res = string_of_ic ic in close_in ic; res
+  with exn -> close_in ic; raise exn
+
+let with_process_exn ?timeout ?env ?stdin:(tmp_stdin = Unix.stdin) ?stdout ?stderr cmd =
+  let tmp_stdout_name = match stdout with
+    | Some name -> name
+    | None -> Filename.temp_file "bench" "stdout"
+  in
+  let tmp_stderr_name = match stderr with
+    | Some name -> name
+    | None -> Filename.temp_file "bench" "stderr"
+  in
+
+  let tmp_stdout = Unix.(openfile tmp_stdout_name [O_WRONLY; O_CREAT; O_TRUNC] 0o600) in
+  let tmp_stderr = Unix.(openfile tmp_stderr_name [O_WRONLY; O_CREAT; O_TRUNC] 0o600) in
+
+  let time_start = Oclock.(gettime monotonic) in
+  match Unix.fork () with
+  | 0 -> (* child *)
+    Unix.(handle_unix_error
+      (fun () -> dup2 tmp_stdout stdout; close tmp_stdout;
+                 dup2 tmp_stderr stderr; close tmp_stderr;
+                 dup2 tmp_stdin stdin; close tmp_stdin;
+
+                 (match env with
+                  | None -> execvp (List.hd cmd) (Array.of_list cmd)
+                  | Some env -> execvpe (List.hd cmd) (Array.of_list cmd) (Array.of_list env)))
+      ())
+  | n ->
+    let (_:int) = match timeout with None -> 0 | Some v -> Unix.alarm v in
+    Sys.(set_signal sigalrm (Signal_handle (fun _ -> ())));
+    let _, process_status = Unix.waitpid [] n in
+    let time_end = Oclock.(gettime monotonic) in
+    Unix.(close tmp_stdout; close tmp_stderr);
+    let res =
+      { process_status
+      ; stdout = string_of_file tmp_stdout_name
+      ; stderr = string_of_file tmp_stderr_name
+      ; duration = Int64.(rem time_end time_start) }
+    in
+
+    (match stdout with
+     | None -> Unix.unlink tmp_stdout_name
+     | Some _ -> ());
+    (match stderr with
+     | None -> Unix.unlink tmp_stderr_name
+     | Some _ -> ());
+    res
+
+let with_process ?timeout ?env ?stdin ?stdout ?stderr cmd =
+  try `Ok (with_process_exn ?timeout ?env ?stdin ?stdout ?stderr cmd)
+  with Unix.Unix_error (Unix.EINTR, _, _) -> `Timeout
+     | exn -> `Error exn
+
+let binaries = [ "zpipe"; "dpipe.native" ]
+
+let do_cmd input_filename =
+  let run_once binary =
+    let stdin = Unix.openfile input_filename [Unix.O_RDONLY] 0o600 in
+    let res   = with_process ~stdin [binary] in
+    Unix.close stdin; res
+  in
+
+  let res = List.map (fun binary -> let e = run_once (Filename.concat (Unix.getcwd ()) binary) in binary, e) binaries in
+  Format.printf "%s\n%!" ([%derive.show: (string * r) list] res)
+
+open Cmdliner
+
+let input_filename =
+  let doc = "Input filename." in
+  Arg.(required & opt (some string) None & info ["i"; "input"] ~doc)
+
+let cmd =
+  let doc = "Benchmark." in
+  let man =
+    [ `S "Description"
+    ; `P "$(tname) is benchmark tool." ] in
+  Term.(pure do_cmd $ input_filename),
+  Term.info "bench" ~doc ~man
+
+let () = match Term.eval cmd with
+  | `Error _ -> exit 1
+  | _ -> exit 0

--- a/lib/decompress.ml
+++ b/lib/decompress.ml
@@ -1,5 +1,4 @@
-module ExtString = Decompress_common.ExtString
-module ExtBytes  = Decompress_common.ExtBytes
+[@@@landmark "auto"]
 
 module Inflate = Decompress_inflate
 module Deflate = Decompress_deflate

--- a/lib/decompress_huffman.ml
+++ b/lib/decompress_huffman.ml
@@ -30,122 +30,34 @@ struct
     | Node (p, e, _, _) as queue -> (p, e, remove queue)
 end
 
-type code = bool list
-
-let pp_code fmt code =
-  Format.fprintf fmt "[@[<hov 2>@;";
-  List.iter (fun b -> Format.fprintf fmt "%d@ " @@ if b then 1 else 0) code;
-  Format.fprintf fmt "@]]"
-
-let int_of_code code =
-  let rec aux acc n = function
-    | [] -> acc
-    | false :: t -> aux acc (n * 2) t
-    | true :: t -> aux (n + acc) (n * 2) t
-  in
-  aux 0 1 (List.rev code)
-
-let code_of_int ~size n =
-  let rec aux acc size = function
-    | n when size > 0 ->
-      if n land 1 = 0
-      then aux (false :: acc) (size - 1) (n lsr 1)
-      else aux (true  :: acc) (size - 1) (n lsr 1)
-    | _ -> List.rev acc
-  in
-  aux [] size n
-
-type t =
-  | Node of t * t
-  | Flat of int * t array
-  | Leaf of int
-
 exception Invalid_huffman
 
-let rec pp pp_a fmt t =
-  let pp_table pp_a fmt table =
-    Array.iter (fun a ->
-        Format.fprintf fmt "\t%a" pp_a a)
-      table
+let prefix heap max =
+  let tbl = Array.make (1 lsl max) (0, 0) in
+
+  let rec backward huff incr =
+    if huff land incr <> 0
+    then backward huff (incr lsr 1)
+    else incr
   in
-  let pp = pp pp_a in
-  match t with
-  | Node (x, y) ->
-    Format.fprintf fmt "Node (@[<hov 2>@,%a,@ %a@])" pp x pp y
-  | Leaf a ->
-    Format.fprintf fmt "Leaf (@[<hov 2>%a@])" pp_a a
-  | Flat (_, table) ->
-    Format.fprintf fmt "Flat (@[<hov 2>%a@])" (pp_table pp) table
 
-let leaf x = Leaf x
+  let rec aux huff heap = match Heap.take heap with
+    | bits, (len, value), heap ->
+      let rec loop decr fill =
+        Array.set tbl (huff + fill) (len, value);
+        if fill <> 0 then loop decr (fill - decr)
+      in
 
-let node ?(canonical = true) x y = match x, y with
-  | Node _, Leaf _ when canonical -> Node (y, x)
-  | _ -> Node (x, y)
+      let decr = 1 lsl len in
+      loop decr ((1 lsl max) - decr);
 
-let rec depth = function
-  | Leaf _ -> 0
-  | Node (a, b) ->
-    1 + min (depth a) (depth b)
-  | Flat (depth, _) -> depth
+      let incr = backward huff (1 lsl (len - 1)) in
 
-let rec decompress = function
-  | Flat (depth, table) ->
-    let rec aux index level depth =
-      if depth > 0
-      then Node (aux index (level + 1) (depth - 1),
-                 aux (index lor (1 lsl level)) (level + 1) (depth - 1))
-      else table.(index)
-    in aux 0 0 depth
-  | n -> n
-
-let rec compress ~default t =
-  match depth t with
-  | 0 -> t
-  | 1 ->
-    begin match t with
-      | Node (a, b) -> Node (compress ~default a, compress ~default b)
-      | Flat (depth, table) when depth = 1 -> t
-      | _ -> assert false
-    end
-  | depth ->
-    let size = 1 lsl depth in (* 2 ** depth *)
-    let table = Array.make size (Leaf default) in
-    walk ~default table 0 0 depth t;
-
-    Flat (depth, table)
-and walk ~default table index level depth = function
-  | Node (a, b) when depth > 0 ->
-    walk ~default table index (level + 1) (depth - 1) a;
-    walk ~default table (index lor (1 lsl level)) (level + 1) (depth - 1) b;
-  | t -> Array.set table index (compress ~default t)
-
-module List =
-struct
-  include List
-
-  let rec min ~default = function
-    | [] -> default
-    | [ x ] -> if x < default then x else default
-    | x :: r -> min ~default:(if x < default then x else default) r
-end
-
-let rec depth = function
-  | Leaf _ -> 0
-  | Node (a, b) ->
-    1 + min (depth a) (depth b)
-  | Flat (d, a) ->
-    List.map (fun x -> d + depth x) (Array.to_list a) |> List.min ~default:d
-
-let rec read_and_find get_bit get_bits node k state =
-  let rec aux tree state = match tree with
-    | Leaf i -> k i state
-    | Node (a, b) ->
-      get_bit (fun bit -> aux (if bit then b else a)) state
-    | Flat (n, a) ->
-      get_bits n (fun nth -> aux (Array.get a nth)) state
+      aux (if incr <> 0 then (huff land (incr - 1)) + incr else 0) heap
+    | exception Heap.Empty_heap -> ()
   in
-  aux node state
+
+  aux 0 heap; tbl
 
 (* This algorithm is describe at RFC 1951 § 3.2.2.
  *
@@ -185,7 +97,6 @@ let make table position size max_bits =
    * (which have a bit length of zero) must not be assigned a
    * value.
   *)
-  let bits = Hashtbl.create 16 in
   let ordered = ref Heap.Empty in
   let max  = ref 0 in
 
@@ -195,59 +106,9 @@ let make table position size max_bits =
     if l <> 0 then begin
       let n = Array.get next_code (l - 1) in
       Array.set next_code (l - 1) (n + 1);
-      Hashtbl.add bits (n, l) i;
       ordered := Heap.push !ordered n (l, i);
       max     := if l > !max then l else !max;
     end;
   done;
 
-  let rec make v l =
-    if l > (max_bits + 1) then raise Invalid_huffman;
-
-    try leaf (Hashtbl.find bits (v, l))
-    with Not_found ->
-      node
-        ~canonical:false
-        (make (v lsl 1) (l + 1)) (make (v lsl 1 lor 1) (l + 1))
-  in
-  let tree = node ~canonical:false (make 0 1) (make 1 1) in
-  compress ~default:(-1) tree, !ordered, !max
-
-let codes_of_t t =
-  let rec aux acc = function
-    | [] -> List.rev acc
-    | (code, Leaf x) :: t -> aux ((code, x) :: acc) t
-    | (code, Node (l, r)) :: t ->
-      let l = false :: code, l in
-      let r = true :: code, r in
-      aux acc (l :: r :: t)
-    | (code, flat) :: t ->
-      aux acc ((code, decompress flat) :: t)
-  in
-  let codes = aux [] [[], t] in
-  List.map (fun (code, x) -> List.rev code, x) codes
-
-let leaf x = Leaf x
-
-let insert_weight (w, _ as e) =
-  let rec aux acc l = match l with
-    | [] -> List.rev_append acc [e]
-    | (x, _ as i) :: r ->
-      if w <= x
-      then List.rev_append acc (e :: l)
-      else aux (i :: acc) r
-  in aux []
-
-let compare_weight (w1, _) (w2, _) = Pervasives.compare w1 w2
-
-let from_distribution ?(canonical = true) l =
-  let rec aux = function
-    | [] -> raise (Invalid_argument "Huffman.from_distribution")
-    | [_, r] -> r
-    | (w1, x1) :: (w2, x2) :: r ->
-      aux (insert_weight (w1 +. w2, node ~canonical x1 x2) r)
-  in
-  (* XXX: sort must be stable *)
-  let l = List.rev (List.sort compare_weight l) in
-  let l = List.map (fun (w, x) -> w, leaf x) l in
-  aux l
+  prefix !ordered !max, !max

--- a/lib/decompress_huffman.mli
+++ b/lib/decompress_huffman.mli
@@ -10,29 +10,4 @@ sig
   val take  : 'a queue -> (priority * 'a * 'a queue)
 end
 
-type code
-
-val pp_code : Format.formatter -> code -> unit
-
-val int_of_code : code -> int
-val code_of_int : size:int -> int -> code
-
-type t =
-  | Node of t * t
-  | Flat of int * t array
-  | Leaf of int
-
-val node: ?canonical:bool -> t -> t -> t
-val leaf: int -> t
-val depth : t -> int
-val compress : default:int -> t -> t
-
-val read_and_find :
-  ((bool -> 'a -> 'b) -> 'a -> 'b) ->
-  (int -> (int -> 'a -> 'b) -> 'a -> 'b) ->
-  t -> (int -> 'a -> 'b) -> 'a -> 'b
-
-val make : int array -> int -> int -> int -> (t * (int * int) Heap.queue * int)
-val from_distribution : ?canonical:bool -> (float * int) list -> t
-
-val codes_of_t : t -> (code * int) list
+val make : int array -> int -> int -> int -> ((int * int) array * int)


### PR DESCRIPTION
From #15 (so after `memcpy` and _defunctorize_ the project)
- Fix a bug with the ring-buffer and blitting into the output
- **TODO**: Fix the checksum (align to the next byte) - but not mandatory to test
- Replace `huffman_read_and_write` by a lookup table (big improvement and stable)

I try [SpaceTime](https://github.com/ocaml/ocaml/pull/585) and [Landmarks](https://github.com/LexiFi/landmarks) to see the bottleneck. The previous bottleneck was `huffman_read_and_write` function (to walk inside the Huffman tree, read and write the symbol founded) - you can see the report [here](http://img.isomorphis.me/fdGrH.png). So, with the lookup table, the translation from the opcode to the symbol is direct (it's just a `Array.get` with a bit-mask). BUT, when I relaunched `landmarks`, I had that;

![landmarks](http://img.isomorphis.me/wCin0.png)

The big time is consumed by the I/O functions (like `peek_bits`) - may be a good news. BUT NOT! With my bench, I have this result:

![lzbench](http://img.isomorphis.me/7Stji.png)

So, the problem is definitely the `caml_modify` barrier because for each byte, I need to update `state.hold` and `state.bits` mutable fields (and you can see this update inside `peek_bits` and `drop_bits`).

PS: `oasis` is bad, and I think, I will use `to_pkg`. If you want to use the inverted stub (to try with the [benchmark](https://github.com/dinosaure/lzbench)), you need to compile with `--enable-stub`, which fails and add `memcpy/memcpy.cmx` just after `lib/libdecompress.so` inside the `_build` directory to compile and it's fine - and yes, I'm lazy to deal with `oasis`.
