### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ocaml/opam:alpine_ocaml-4.03.0
+COPY . /home/opam/src
+RUN sudo chown -R opam /home/opam/src
+RUN opam pin add -n decompress /home/opam/src
+RUN opam depext -uivj 3 decompress


### PR DESCRIPTION
no binaries seem to be installed though -- could we have a
`decompress.install` file that adds them to the opam bin path?

closes #21