### PR TITLE
optionally depend on cmdliner

### DIFF
--- a/opam
+++ b/opam
@@ -8,10 +8,15 @@ bug-reports:  "https://github.com/oklm-wsh/Decompress/issues"
 dev-repo:     "https://github.com/oklm-wsh/Decompress.git"
 license:      "MIT"
 
-build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" pinned ]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+  "--with-cmdliner" "%{cmdliner:installed}%"
+]
 
-build-test: [ [ "ocaml" "pkg/pkg.ml" "build" "--pinned" pinned "--tests" "true" ]
-              [ "ocaml" "pkg/pkg.ml" "test" ] ]
+build-test: [
+  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+  [ "ocaml" "pkg/pkg.ml" "test" ]
+]
 
 depends: [
   "ocamlbuild"     {build}
@@ -21,6 +26,10 @@ depends: [
   "camlzip"        {test}
   "re"             {test}
   "alcotest"       {test}
+]
+
+depopts: [
+  "cmdliner"
 ]
 
 available: [ocaml-version >= "4.03.0"]

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,17 +1,14 @@
 #!/usr/bin/env ocaml
-
-#directory "pkg";;
 #use       "topfind";;
 #require   "topkg";;
 
 open Topkg
 
 let unix = Conf.with_pkg "unix"
-let cmdliner = Conf.with_pkg "cmdliner"
-let opam = Pkg.opam_file ~lint_deps_excluding:None "opam"
+let cmdliner = Conf.with_pkg ~default:false "cmdliner"
 
 let () =
-  Pkg.describe ~opams:[opam] "decompress" @@ fun c ->
+  Pkg.describe "decompress" @@ fun c ->
 
   let unix = Conf.value c unix in
   let cmdliner = Conf.value c cmdliner in


### PR DESCRIPTION
`cmdliner` support was by default enabled, and not conditional in `opam`.  This lead to compilation failure if `cmdliner` is not installed.